### PR TITLE
feat-24-dbt-schema-yml-extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "sqlglot>=28.0.0,<30",
     "pydantic>=2.0.0",
     "click>=8.0.0",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]

--- a/src/sqlprism/languages/dbt.py
+++ b/src/sqlprism/languages/dbt.py
@@ -17,6 +17,7 @@ The dbt command can be customised (e.g. "uvx --with dbt-starrocks dbt" or
 just "dbt" if globally installed).
 """
 
+import logging
 import shlex
 import subprocess
 from pathlib import Path
@@ -25,6 +26,8 @@ from sqlprism.languages.sql import SqlParser
 from sqlprism.languages.sqlmesh import _validate_command
 from sqlprism.languages.utils import build_env, enrich_nodes, find_venv_dir
 from sqlprism.types import ColumnDefResult, ParseResult
+
+logger = logging.getLogger(__name__)
 
 
 class DbtRenderer:
@@ -277,8 +280,9 @@ class DbtRenderer:
         """Extract column definitions from dbt schema.yml files.
 
         Scans all ``*.yml`` and ``*.yaml`` files under the project's ``models/``
-        directory for model entries with ``columns:`` lists. Returns a mapping
-        of model name to ``ColumnDefResult`` entries with ``source='schema_yml'``.
+        directory for model and source entries with ``columns:`` lists. Returns
+        a mapping of model name to ``ColumnDefResult`` entries with
+        ``source='schema_yml'``.
 
         Args:
             project_path: Path to dbt project dir (containing ``models/``).
@@ -295,53 +299,74 @@ class DbtRenderer:
 
         result: dict[str, list[ColumnDefResult]] = {}
 
-        for pattern in ("**/*.yml", "**/*.yaml"):
-            for yml_file in models_dir.glob(pattern):
-                try:
-                    data = yaml.safe_load(yml_file.read_text())
-                except Exception:
+        yml_files = [f for f in models_dir.rglob("*") if f.suffix in (".yml", ".yaml")]
+        for yml_file in yml_files:
+            try:
+                data = yaml.safe_load(yml_file.read_text())
+            except Exception as e:
+                logger.warning("Skipping malformed YAML %s: %s", yml_file, e)
+                continue
+
+            if not isinstance(data, dict):
+                continue
+
+            # Extract columns from models: entries
+            for model in data.get("models") or []:
+                if not isinstance(model, dict):
                     continue
-
-                if not isinstance(data, dict):
+                model_name = model.get("name")
+                if not model_name:
                     continue
+                self._extract_yml_columns(model_name, model.get("columns"), result)
 
-                models = data.get("models")
-                if not isinstance(models, list):
+            # Extract columns from sources: entries
+            for source_entry in data.get("sources") or []:
+                if not isinstance(source_entry, dict):
                     continue
-
-                for model in models:
-                    if not isinstance(model, dict):
+                source_name = source_entry.get("name", "")
+                for table_entry in source_entry.get("tables") or []:
+                    if not isinstance(table_entry, dict):
                         continue
-                    model_name = model.get("name")
-                    if not model_name:
+                    table_name = table_entry.get("name")
+                    if not table_name:
                         continue
-
-                    columns = model.get("columns")
-                    if not isinstance(columns, list):
-                        continue
-
-                    col_defs: list[ColumnDefResult] = []
-                    for position, col in enumerate(columns):
-                        if not isinstance(col, dict):
-                            continue
-                        col_name = col.get("name")
-                        if not col_name:
-                            continue
-                        col_defs.append(
-                            ColumnDefResult(
-                                node_name=model_name,
-                                column_name=col_name,
-                                data_type=col.get("data_type"),
-                                position=position,
-                                source="schema_yml",
-                                description=col.get("description"),
-                            )
-                        )
-
-                    if col_defs:
-                        if model_name in result:
-                            result[model_name].extend(col_defs)
-                        else:
-                            result[model_name] = col_defs
+                    full_name = f"{source_name}.{table_name}" if source_name else table_name
+                    self._extract_yml_columns(full_name, table_entry.get("columns"), result)
 
         return result
+
+    @staticmethod
+    def _extract_yml_columns(
+        model_name: str,
+        columns: list | None,
+        result: dict[str, list[ColumnDefResult]],
+    ) -> None:
+        """Extract ColumnDefResult entries from a YAML columns list."""
+        if not isinstance(columns, list):
+            return
+
+        # Offset position to avoid collision when same model spans multiple files
+        offset = len(result[model_name]) if model_name in result else 0
+        col_defs: list[ColumnDefResult] = []
+        for i, col in enumerate(columns):
+            if not isinstance(col, dict):
+                continue
+            col_name = col.get("name")
+            if not col_name:
+                continue
+            col_defs.append(
+                ColumnDefResult(
+                    node_name=model_name,
+                    column_name=col_name,
+                    data_type=col.get("data_type"),
+                    position=offset + i,
+                    source="schema_yml",
+                    description=col.get("description"),
+                )
+            )
+
+        if col_defs:
+            if model_name in result:
+                result[model_name].extend(col_defs)
+            else:
+                result[model_name] = col_defs

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1033,3 +1033,107 @@ models:
 
     assert "stg_customers" in result
     assert result["stg_customers"][0].column_name == "customer_id"
+
+
+def test_extract_schema_yml_no_models_dir(tmp_path):
+    """Missing models/ directory returns empty dict."""
+    renderer = DbtRenderer()
+    result = renderer.extract_schema_yml(tmp_path)
+    assert result == {}
+
+
+def test_extract_schema_yml_malformed_yaml(tmp_path):
+    """Malformed YAML files are skipped without raising."""
+    _write_yaml(
+        tmp_path / "models" / "broken.yml",
+        "!!invalid: [yaml\n  bad: {indent",
+    )
+    _write_yaml(
+        tmp_path / "models" / "good.yml",
+        """\
+version: 2
+
+models:
+  - name: good_model
+    columns:
+      - name: id
+""",
+    )
+
+    renderer = DbtRenderer()
+    result = renderer.extract_schema_yml(tmp_path)
+    # Broken file skipped, good file still parsed
+    assert "good_model" in result
+    assert result["good_model"][0].column_name == "id"
+
+
+def test_extract_schema_yml_duplicate_model_across_files(tmp_path):
+    """Same model in two files: columns merged with offset positions."""
+    _write_yaml(
+        tmp_path / "models" / "a.yml",
+        """\
+version: 2
+
+models:
+  - name: stg_orders
+    columns:
+      - name: order_id
+      - name: status
+""",
+    )
+    _write_yaml(
+        tmp_path / "models" / "b.yml",
+        """\
+version: 2
+
+models:
+  - name: stg_orders
+    columns:
+      - name: amount
+""",
+    )
+
+    renderer = DbtRenderer()
+    result = renderer.extract_schema_yml(tmp_path)
+    assert "stg_orders" in result
+    cols = result["stg_orders"]
+    assert len(cols) == 3
+    names = [c.column_name for c in cols]
+    assert "order_id" in names
+    assert "status" in names
+    assert "amount" in names
+    # Positions should not collide — second file offset by first file's count
+    positions = [c.position for c in cols]
+    assert len(set(positions)) == 3  # all unique
+
+
+def test_extract_schema_yml_sources(tmp_path):
+    """sources: blocks with tables and columns are extracted."""
+    _write_yaml(
+        tmp_path / "models" / "sources.yml",
+        """\
+version: 2
+
+sources:
+  - name: raw
+    tables:
+      - name: orders
+        columns:
+          - name: order_id
+            description: "PK"
+          - name: total
+      - name: customers
+        columns:
+          - name: customer_id
+""",
+    )
+
+    renderer = DbtRenderer()
+    result = renderer.extract_schema_yml(tmp_path)
+    assert "raw.orders" in result
+    assert len(result["raw.orders"]) == 2
+    assert result["raw.orders"][0].column_name == "order_id"
+    assert result["raw.orders"][0].description == "PK"
+    assert result["raw.orders"][0].source == "schema_yml"
+    assert "raw.customers" in result
+    assert result["raw.customers"][0].column_name == "customer_id"


### PR DESCRIPTION
Closes #24

## Summary
- Add `extract_schema_yml()` method to `DbtRenderer`
- Scans `*.yml` and `*.yaml` files in dbt `models/` directory for column definitions
- Supports both `models:` and `sources:` blocks
- Returns `ColumnDefResult` entries with `source='schema_yml'`
- Add `pyyaml>=6.0` to dependencies
- Handles: position offset for multi-file models, malformed YAML logging, single-pass glob

## Test Plan
| Scenario | Test | Status |
|----------|------|--------|
| Standard schema.yml | `test_extract_schema_yml_standard` | :white_check_mark: |
| Multiple files | `test_extract_schema_yml_multiple_files` | :white_check_mark: |
| No columns | `test_extract_schema_yml_no_columns` | :white_check_mark: |
| Tests no desc | `test_extract_schema_yml_tests_no_desc` | :white_check_mark: |
| Non-standard names | `test_extract_schema_yml_non_standard_names` | :white_check_mark: |
| No models dir | `test_extract_schema_yml_no_models_dir` | :white_check_mark: |
| Malformed YAML | `test_extract_schema_yml_malformed_yaml` | :white_check_mark: |
| Duplicate model | `test_extract_schema_yml_duplicate_model_across_files` | :white_check_mark: |
| Sources block | `test_extract_schema_yml_sources` | :white_check_mark: |