### PR TITLE
feat-26-column-insertion-indexer

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -1086,8 +1086,10 @@ class GraphDB:
         """
         schema: dict[str, dict[str, str]] = {}
 
-        # 1. Authoritative columns from columns table (with real types)
-        if repo_id:
+        # 1. Authoritative columns from columns table (with real types).
+        # Note: phantom nodes (file_id IS NULL) are intentionally excluded
+        # since they lack a verified repo association.
+        if repo_id is not None:
             col_rows = self._execute_read(
                 "SELECT n.name, c.column_name, c.data_type "
                 "FROM columns c "
@@ -1109,7 +1111,7 @@ class GraphDB:
             schema[table][col] = dtype or "TEXT"
 
         # 2. Fallback: fill gaps from column_usage
-        if repo_id:
+        if repo_id is not None:
             usage_rows = self._execute_read(
                 "SELECT DISTINCT cu.table_name, cu.column_name "
                 "FROM column_usage cu "

--- a/src/sqlprism/core/indexer.py
+++ b/src/sqlprism/core/indexer.py
@@ -125,6 +125,7 @@ class Indexer:
             "nodes_added": 0,
             "edges_added": 0,
             "column_usage_added": 0,
+            "columns_added": 0,
             "lineage_chains": 0,
             "column_usage_dropped": 0,
             "parse_errors": [],
@@ -230,6 +231,7 @@ class Indexer:
             "nodes_added": 0,
             "edges_added": 0,
             "column_usage_added": 0,
+            "columns_added": 0,
             "lineage_chains": 0,
         }
 
@@ -303,6 +305,7 @@ class Indexer:
             "nodes_added": 0,
             "edges_added": 0,
             "column_usage_added": 0,
+            "columns_added": 0,
             "lineage_chains": 0,
         }
 
@@ -495,7 +498,7 @@ class Indexer:
                 file_id = self.graph.insert_file(repo_id, rel_path, "sql", checksum)
                 insert_stats = {
                     "nodes_added": 0, "edges_added": 0,
-                    "column_usage_added": 0, "lineage_chains": 0,
+                    "column_usage_added": 0, "columns_added": 0, "lineage_chains": 0,
                 }
                 self._insert_parse_result(result, file_id, repo_id, insert_stats)
 
@@ -575,7 +578,7 @@ class Indexer:
                 file_id = self.graph.insert_file(repo_id, model_path, "sql", checksum)
                 insert_stats = {
                     "nodes_added": 0, "edges_added": 0,
-                    "column_usage_added": 0, "lineage_chains": 0,
+                    "column_usage_added": 0, "columns_added": 0, "lineage_chains": 0,
                 }
                 self._insert_parse_result(result, file_id, repo_id, insert_stats)
             stats["reindexed"] += 1
@@ -640,7 +643,7 @@ class Indexer:
                 file_id = self.graph.insert_file(repo_id, file_path_key, "sql", checksum)
                 insert_stats = {
                     "nodes_added": 0, "edges_added": 0,
-                    "column_usage_added": 0, "lineage_chains": 0,
+                    "column_usage_added": 0, "columns_added": 0, "lineage_chains": 0,
                 }
                 self._insert_parse_result(result, file_id, repo_id, insert_stats)
             stats["reindexed"] += 1
@@ -810,10 +813,10 @@ class Indexer:
         if result.columns:
             col_rows = []
             for col_def in result.columns:
-                # Try to resolve node_id from local map (search all schemas)
+                # Try to resolve node_id from local map (table/view only, matching kind)
                 node_id = None
                 for key, nid in node_id_map.items():
-                    if key[0] == col_def.node_name:
+                    if key[0] == col_def.node_name and key[1] in ("table", "view", "source"):
                         node_id = nid
                         break
                 # Fall back to graph resolution
@@ -821,6 +824,8 @@ class Indexer:
                     node_id = self.graph.resolve_node(col_def.node_name, "table", repo_id)
                 if not node_id:
                     node_id = self.graph.resolve_node(col_def.node_name, "view", repo_id)
+                if not node_id:
+                    node_id = self.graph.resolve_node(col_def.node_name, "source", repo_id)
                 if not node_id:
                     logger.warning(
                         "Column def skipped: cannot resolve node '%s' for column '%s'",
@@ -840,7 +845,7 @@ class Indexer:
                 )
             if col_rows:
                 self.graph.insert_columns_batch(col_rows)
-            stats["columns_added"] = stats.get("columns_added", 0) + len(col_rows)
+            stats["columns_added"] += len(col_rows)
 
     def _resolve_edge_endpoint(
         self,

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1566,21 +1566,29 @@ def test_insert_parse_result_stores_columns():
         "nodes_added": 0,
         "edges_added": 0,
         "column_usage_added": 0,
+        "columns_added": 0,
         "lineage_chains": 0,
     }
 
     with db.write_transaction():
         indexer._insert_parse_result(result, file_id, repo_id, stats)
 
+    # Verify node_id matches the orders node
+    orders_node_id = db._execute_read(
+        "SELECT node_id FROM nodes WHERE name = 'orders'"
+    ).fetchone()[0]
+
     rows = db._execute_read(
         "SELECT node_id, column_name, data_type, position, source FROM columns ORDER BY position"
     ).fetchall()
 
     assert len(rows) == 2
+    assert rows[0][0] == orders_node_id
     assert rows[0][1] == "order_id"
     assert rows[0][2] == "INT"
     assert rows[0][3] == 0
     assert rows[0][4] == "definition"
+    assert rows[1][0] == orders_node_id
     assert rows[1][1] == "status"
     assert rows[1][2] == "TEXT"
     assert rows[1][3] == 1
@@ -1621,6 +1629,7 @@ def test_columns_multiple_sources_merged():
         "nodes_added": 0,
         "edges_added": 0,
         "column_usage_added": 0,
+        "columns_added": 0,
         "lineage_chains": 0,
     }
 
@@ -1645,11 +1654,15 @@ def test_columns_multiple_sources_merged():
     ).fetchall()
 
     assert len(rows) == 2
-    # Upsert: schema_yml wins for source, but data_type is preserved via COALESCE
-    for row in rows:
-        assert row[1] is not None  # data_type preserved from definition
-        assert row[2] == "schema_yml"  # source updated
-        assert row[3] is not None  # description set from schema_yml
+    # Build dict for robust lookup regardless of ordering
+    by_name = {r[0]: r for r in rows}
+    # Upsert: schema_yml wins for source, data_type preserved via COALESCE
+    assert by_name["order_id"][1] == "INT"  # data_type preserved from definition
+    assert by_name["order_id"][2] == "schema_yml"  # source updated
+    assert by_name["order_id"][3] == "The unique order identifier"
+    assert by_name["status"][1] == "TEXT"  # data_type preserved from definition
+    assert by_name["status"][2] == "schema_yml"  # source updated
+    assert by_name["status"][3] == "Current order status"
 
     db.close()
 
@@ -1778,6 +1791,7 @@ def test_columns_batch_insert():
         "nodes_added": 0,
         "edges_added": 0,
         "column_usage_added": 0,
+        "columns_added": 0,
         "lineage_chains": 0,
     }
 
@@ -1787,6 +1801,91 @@ def test_columns_batch_insert():
     rows = db._execute_read("SELECT COUNT(*) FROM columns").fetchone()
     assert rows[0] == num_columns
 
-    assert stats["columns_added"] >= 50
+    assert stats["columns_added"] == 55
+
+    db.close()
+
+
+def test_column_def_unresolved_node_skipped():
+    """Column definitions for unresolved node names are skipped with warning."""
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    db = GraphDB()
+    indexer = Indexer(db)
+    repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sql")
+
+    with db.write_transaction():
+        file_id = db.insert_file(repo_id, "ghost.sql", "sql", "abc123")
+
+    # ColumnDefResult references a node that doesn't exist anywhere
+    result = ParseResult(
+        language="sql",
+        nodes=[],  # no nodes — ghost_table won't be found
+        columns=[
+            ColumnDefResult(
+                node_name="ghost_table", column_name="col_a",
+                data_type="INT", position=0, source="definition",
+            ),
+        ],
+    )
+
+    stats = {
+        "nodes_added": 0,
+        "edges_added": 0,
+        "column_usage_added": 0,
+        "columns_added": 0,
+        "lineage_chains": 0,
+    }
+
+    with db.write_transaction():
+        indexer._insert_parse_result(result, file_id, repo_id, stats)
+
+    assert stats["columns_added"] == 0
+    rows = db._execute_read("SELECT COUNT(*) FROM columns").fetchone()
+    assert rows[0] == 0
+
+    db.close()
+
+
+def test_column_def_null_data_type_returns_text():
+    """Column with data_type=None is returned as TEXT by get_table_columns."""
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    db = GraphDB()
+    indexer = Indexer(db)
+    repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sql")
+
+    with db.write_transaction():
+        file_id = db.insert_file(repo_id, "inferred.sql", "sql", "abc123")
+
+    result = ParseResult(
+        language="sql",
+        nodes=[NodeResult(kind="table", name="inferred_table")],
+        columns=[
+            ColumnDefResult(
+                node_name="inferred_table", column_name="unknown_col",
+                data_type=None, position=0, source="inferred",
+            ),
+        ],
+    )
+
+    stats = {
+        "nodes_added": 0,
+        "edges_added": 0,
+        "column_usage_added": 0,
+        "columns_added": 0,
+        "lineage_chains": 0,
+    }
+
+    with db.write_transaction():
+        indexer._insert_parse_result(result, file_id, repo_id, stats)
+
+    assert stats["columns_added"] == 1
+
+    schema = db.get_table_columns(repo_id)
+    assert "inferred_table" in schema
+    assert schema["inferred_table"]["unknown_col"] == "TEXT"
 
     db.close()


### PR DESCRIPTION
Closes #26

## Summary
- Insert `ColumnDefResult` entries into the `columns` table during `_insert_parse_result()` with batch insert and node_id resolution from local map or graph
- Update `get_table_columns()` to prefer authoritative `columns` table (real data types) with fallback merge from `column_usage`
- Backwards compatible: when columns table is empty, behavior is identical to previous implementation

## Test Plan
| Scenario | Test | Status |
|----------|------|--------|
| Columns stored during reindex | `test_insert_parse_result_stores_columns` | passing |
| Multiple sources merged | `test_columns_multiple_sources_merged` | passing |
| get_table_columns prefers columns table | `test_get_table_columns_prefers_columns_table` | passing |
| get_table_columns falls back to usage | `test_get_table_columns_fallback_column_usage` | passing |
| Merged result combines sources | `test_get_table_columns_merged_result` | passing |
| Batch insert performance | `test_columns_batch_insert` | passing |