### PR TITLE
feat-27-get-schema-tool

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -1151,14 +1151,15 @@ class GraphDB:
             ``upstream``, and ``downstream`` keys.  Returns an ``error``
             key when the entity is not found.
         """
-        # 1. Find the node
+        # 1. Find the node — ORDER BY prefers real nodes over phantoms
         if repo:
             node_rows = self._execute_read(
                 "SELECT n.node_id, n.kind, f.path, r.name "
                 "FROM nodes n "
                 "LEFT JOIN files f ON n.file_id = f.file_id "
                 "LEFT JOIN repos r ON f.repo_id = r.repo_id "
-                "WHERE n.name = ? AND r.name = ?",
+                "WHERE n.name = ? AND r.name = ? "
+                "ORDER BY (n.file_id IS NULL), n.node_id DESC",
                 [name, repo],
             ).fetchall()
         else:
@@ -1167,26 +1168,26 @@ class GraphDB:
                 "FROM nodes n "
                 "LEFT JOIN files f ON n.file_id = f.file_id "
                 "LEFT JOIN repos r ON f.repo_id = r.repo_id "
-                "WHERE n.name = ?",
+                "WHERE n.name = ? AND n.file_id IS NOT NULL "
+                "ORDER BY n.node_id DESC",
                 [name],
             ).fetchall()
 
         if not node_rows:
             return {"error": f"Model '{name}' not found in the index."}
 
-        # Use the first match; collect all node_ids for edge queries
+        # Use the first match (real node preferred) for all queries
         first = node_rows[0]
+        node_id = first[0]
         node_kind = first[1]
         file_path = first[2]
         repo_name = first[3]
-        node_ids = [row[0] for row in node_rows]
-        placeholders = ",".join(["?"] * len(node_ids))
 
-        # 2. Get columns from the first node
+        # 2. Get columns
         col_rows = self._execute_read(
             "SELECT column_name, data_type, position, source, description "
             "FROM columns WHERE node_id = ? ORDER BY position",
-            [node_ids[0]],
+            [node_id],
         ).fetchall()
 
         columns = [
@@ -1202,27 +1203,27 @@ class GraphDB:
 
         # 3. Get upstream (outbound edges — what this node references)
         upstream_rows = self._execute_read(
-            f"SELECT DISTINCT n2.name, n2.kind "
-            f"FROM edges e "
-            f"JOIN nodes n2 ON e.target_id = n2.node_id "
-            f"WHERE e.source_id IN ({placeholders})",
-            node_ids,
+            "SELECT DISTINCT n2.name, n2.kind "
+            "FROM edges e "
+            "JOIN nodes n2 ON e.target_id = n2.node_id "
+            "WHERE e.source_id = ?",
+            [node_id],
         ).fetchall()
 
         upstream = [{"name": r[0], "kind": r[1]} for r in upstream_rows]
 
         # 4. Get downstream (inbound edges — what depends on this node)
         downstream_rows = self._execute_read(
-            f"SELECT DISTINCT n2.name, n2.kind "
-            f"FROM edges e "
-            f"JOIN nodes n2 ON e.source_id = n2.node_id "
-            f"WHERE e.target_id IN ({placeholders})",
-            node_ids,
+            "SELECT DISTINCT n2.name, n2.kind "
+            "FROM edges e "
+            "JOIN nodes n2 ON e.source_id = n2.node_id "
+            "WHERE e.target_id = ?",
+            [node_id],
         ).fetchall()
 
         downstream = [{"name": r[0], "kind": r[1]} for r in downstream_rows]
 
-        return {
+        result = {
             "name": name,
             "kind": node_kind,
             "file": file_path,
@@ -1231,6 +1232,9 @@ class GraphDB:
             "upstream": upstream,
             "downstream": downstream,
         }
+        if len(node_rows) > 1:
+            result["matches"] = len(node_rows)
+        return result
 
     # ── Snippet helper ──
 

--- a/src/sqlprism/core/mcp_tools.py
+++ b/src/sqlprism/core/mcp_tools.py
@@ -360,6 +360,7 @@ async def trace_column_lineage(params: TraceColumnLineageInput) -> dict:
 
 
 class GetSchemaInput(BaseModel):
+    model_config = {"populate_by_name": True}
     name: str = Field(..., description="Table or model name (e.g. 'staging.orders', 'stg_orders')")
     repo: str | None = Field(
         None,

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -10,6 +10,7 @@ import sqlprism.core.mcp_tools as _mcp_mod
 from sqlprism.core.mcp_tools import (
     FindColumnUsageInput,
     FindReferencesInput,
+    GetSchemaInput,
     PrImpactInput,
     ReindexFilesInput,
     ReindexInput,
@@ -21,6 +22,7 @@ from sqlprism.core.mcp_tools import (
     configure,
     find_column_usage,
     find_references,
+    get_schema,
     index_status,
     pr_impact,
     reindex,
@@ -1299,6 +1301,7 @@ def test_get_schema_with_columns():
     assert cols_by_name["amount"]["position"] == 2
     for col in result["columns"]:
         assert col["source"] == "definition"
+        assert col["description"] is None
 
     db.close()
 
@@ -1334,6 +1337,9 @@ def test_get_schema_dbt_descriptions():
     # Descriptions added from schema_yml pass
     assert cols_by_name["order_id"]["description"] == "Primary key for orders"
     assert cols_by_name["status"]["description"] == "Current order status"
+    # Source updated to schema_yml by upsert
+    assert cols_by_name["order_id"]["source"] == "schema_yml"
+    assert cols_by_name["status"]["source"] == "schema_yml"
 
     db.close()
 
@@ -1347,7 +1353,7 @@ def test_get_schema_unknown_model():
 
     result = db.query_schema("nonexistent_table")
 
-    assert "error" in result
+    assert list(result.keys()) == ["error"]
     assert "nonexistent_table" in result["error"]
 
     db.close()
@@ -1367,10 +1373,14 @@ def test_get_schema_repo_filter():
         db.insert_node(file_b, "table", "orders", "sql")
 
     result_a = db.query_schema("orders", repo="repo_a")
+    assert result_a["name"] == "orders"
     assert result_a["repo"] == "repo_a"
+    assert result_a["columns"] == []
 
     result_b = db.query_schema("orders", repo="repo_b")
+    assert result_b["name"] == "orders"
     assert result_b["repo"] == "repo_b"
+    assert result_b["columns"] == []
 
     db.close()
 
@@ -1393,10 +1403,87 @@ def test_get_schema_upstream_downstream():
 
     result = db.query_schema("staging_orders")
 
-    upstream_names = {u["name"] for u in result["upstream"]}
-    assert "raw_orders" in upstream_names
+    assert len(result["upstream"]) == 1
+    assert result["upstream"][0]["name"] == "raw_orders"
 
-    downstream_names = {d["name"] for d in result["downstream"]}
-    assert "marts_revenue" in downstream_names
+    assert len(result["downstream"]) == 1
+    assert result["downstream"][0]["name"] == "marts_revenue"
 
     db.close()
+
+
+def test_get_schema_ambiguous_no_repo_filter():
+    """query_schema without repo filter returns first match with matches count."""
+    from sqlprism.core.graph import GraphDB
+
+    db = GraphDB()
+    repo_a_id = db.upsert_repo("repo_a", "/tmp/repo_a", repo_type="sql")
+    repo_b_id = db.upsert_repo("repo_b", "/tmp/repo_b", repo_type="sql")
+    with db.write_transaction():
+        file_a = db.insert_file(repo_a_id, "orders.sql", "sql", "aaa")
+        db.insert_node(file_a, "table", "orders", "sql")
+        file_b = db.insert_file(repo_b_id, "orders.sql", "sql", "bbb")
+        db.insert_node(file_b, "table", "orders", "sql")
+
+    result = db.query_schema("orders")
+
+    # Should return a result (not error), with ambiguity indicator
+    assert "error" not in result
+    assert result["name"] == "orders"
+    assert result["matches"] == 2
+
+    db.close()
+
+
+def test_get_schema_null_data_type_returns_unknown():
+    """query_schema returns UNKNOWN for columns with NULL data_type."""
+    from sqlprism.core.graph import GraphDB
+
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sql")
+    with db.write_transaction():
+        file_id = db.insert_file(repo_id, "inferred.sql", "sql", "abc123")
+        node_id = db.insert_node(file_id, "table", "inferred_table", "sql")
+        db.insert_columns_batch([
+            (node_id, "known_col", "INT", 0, "definition", None),
+            (node_id, "unknown_col", None, 1, "inferred", None),
+        ])
+
+    result = db.query_schema("inferred_table")
+
+    cols_by_name = {c["name"]: c for c in result["columns"]}
+    assert cols_by_name["known_col"]["type"] == "INT"
+    assert cols_by_name["unknown_col"]["type"] == "UNKNOWN"
+
+    db.close()
+
+
+def test_get_schema_mcp_tool_integration(tmp_path):
+    """get_schema MCP tool returns schema via async-to-thread bridge."""
+    repo_dir = tmp_path / "test_repo"
+    repo_dir.mkdir()
+    (repo_dir / "orders.sql").write_text("CREATE TABLE orders (id INT, name TEXT);")
+
+    configure(db_path=":memory:", repos={"test": str(repo_dir)})
+
+    state = _mcp_mod._state
+    graph = state.graph
+
+    # Manually insert a node with columns (reindex would parse but we want control)
+    repo_id = graph.upsert_repo("test", str(repo_dir), repo_type="sql")
+    with graph.write_transaction():
+        file_id = graph.insert_file(repo_id, "orders.sql", "sql", "abc123")
+        node_id = graph.insert_node(file_id, "table", "orders", "sql")
+        graph.insert_columns_batch([
+            (node_id, "id", "INT", 0, "definition", None),
+            (node_id, "name", "TEXT", 1, "definition", None),
+        ])
+
+    result = asyncio.run(get_schema(GetSchemaInput(name="orders")))
+
+    assert result["name"] == "orders"
+    assert result["kind"] == "table"
+    assert result["repo"] == "test"
+    assert len(result["columns"]) == 2
+
+    graph.close()


### PR DESCRIPTION
Closes #27

## Summary
- Add `query_schema()` method to GraphDB — returns column definitions (types, positions, sources, descriptions), upstream/downstream dependencies, and file/repo metadata for a named table or model
- Add `get_schema` MCP tool with `GetSchemaInput` (name, optional repo filter) and read-only annotations
- Supports repo filtering for disambiguation when same model name exists in multiple repos
- Returns clear error message for unknown models

## Test Plan
| Scenario | Test | Status |
|----------|------|--------|
| Table with column definitions | `test_get_schema_with_columns` | passing |
| Model with dbt descriptions | `test_get_schema_dbt_descriptions` | passing |
| Unknown model | `test_get_schema_unknown_model` | passing |
| Repo filter | `test_get_schema_repo_filter` | passing |
| Upstream and downstream | `test_get_schema_upstream_downstream` | passing |