### PR TITLE
feat-31-trace-pgq

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -1942,7 +1942,7 @@ class GraphDB:
         limit: int = 100,
         exclude_edges: set[tuple[str, str]] | None = None,
     ) -> dict:
-        """Trace multi-hop dependency chains using a recursive CTE.
+        """Trace multi-hop dependency chains via DuckPGQ or recursive CTE.
 
         Args:
             name: Starting entity name.
@@ -1968,7 +1968,7 @@ class GraphDB:
             ``direction="both"``, paths are split into ``"downstream"``
             and ``"upstream"`` keys instead of a single ``"paths"``.
         """
-        max_depth = min(max_depth, 10)
+        max_depth = max(min(max_depth, 10), 1)
         # Find starting node(s)
         where = ["name = ?"]
         params: list = [name]
@@ -2210,6 +2210,9 @@ class GraphDB:
         depth_map: dict[int, int] = {r[0]: r[1] for r in depth_rows}
 
         # Step 3: Enrich with metadata (file, repo, edge relationship)
+        # Include start_id in edge source lookup so depth-1 nodes get real relationship
+        source_ids = [start_id] + node_ids
+        source_ph = ",".join("?" for _ in source_ids)
         enrich_sql = (
             f"SELECT n.node_id, n.name, n.kind, n.language, "
             f"n.line_start, n.line_end, f.path, r.name, "
@@ -2218,12 +2221,12 @@ class GraphDB:
             f"LEFT JOIN files f ON n.file_id = f.file_id "
             f"LEFT JOIN repos r ON f.repo_id = r.repo_id "
             f"LEFT JOIN edges e ON e.{target_col} = n.node_id "
-            f"AND e.{source_col} IN ({placeholders}) "
+            f"AND e.{source_col} IN ({source_ph}) "
             f"WHERE n.node_id IN ({placeholders}) "
             f"AND n.file_id IS NOT NULL "
             f"ORDER BY n.name"
         )
-        enrich_params = node_ids + node_ids
+        enrich_params = source_ids + node_ids
         rows = self._execute_read(enrich_sql, enrich_params).fetchall()
 
         seen: set[int] = set()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1368,14 +1368,14 @@ def test_duckpgq_tools_check_flag():
 def _build_trace_graph():
     """Create a graph with known topology for trace tests.
 
-    Topology:
-        raw_orders <- stg_orders <- marts_revenue
-        raw_orders <- dim_customers
+    Topology (downstream flow):
+        raw_orders -> stg_orders -> marts_revenue
+        raw_orders -> dim_customers
 
-    Edges point source -> target where source references target:
-        stg_orders  -> raw_orders
-        marts_revenue -> stg_orders
-        dim_customers -> raw_orders
+    Edges follow source -> target for downstream traversal:
+        raw_orders  -> stg_orders
+        stg_orders  -> marts_revenue
+        raw_orders  -> dim_customers
     """
     db = GraphDB()
     repo_id = db.upsert_repo("trace-repo", "/tmp/trace")
@@ -1454,6 +1454,7 @@ def test_pr_impact_duckpgq_multi_root():
 
     # Trace from raw_orders — should find all three dependants
     result_raw = db.query_trace("raw_orders", direction="downstream")
+    _assert_trace_structure(result_raw)
     names_raw = {p["name"] for p in result_raw["paths"]}
     assert names_raw == {"stg_orders", "marts_revenue", "dim_customers"}
 
@@ -1476,6 +1477,7 @@ def test_pr_impact_cte_fallback():
         exclude_edges={("raw_orders", "stg_orders")},
     )
 
+    _assert_trace_structure(result)
     names = {p["name"] for p in result["paths"]}
     assert names == {"dim_customers"}
     db.close()
@@ -1499,6 +1501,7 @@ def test_pr_impact_exclude_edges_forces_cte():
         exclude_edges={("raw_orders", "stg_orders")},
     )
 
+    _assert_trace_structure(result)
     names = {p["name"] for p in result["paths"]}
     # CTE with exclusion: stg_orders and marts_revenue unreachable
     assert names == {"dim_customers"}
@@ -1512,6 +1515,7 @@ def test_trace_max_depth_boundary():
 
     result = db.query_trace("raw_orders", direction="downstream", max_depth=1)
 
+    _assert_trace_structure(result)
     names = {p["name"] for p in result["paths"]}
     # Only depth-1 nodes: stg_orders and dim_customers (not marts_revenue at depth 2)
     assert names == {"stg_orders", "dim_customers"}


### PR DESCRIPTION
Closes #31

## Summary
- Refactor `query_trace()` to dispatch between DuckPGQ and CTE implementations
- Extract existing recursive CTE logic to `_trace_cte()` — preserved unchanged
- Add `_trace_pgq()` using `GRAPH_TABLE` bounded traversal for node discovery + single enrichment query
- Dispatch: PGQ when `has_pgq=True` and no `exclude_edges`, CTE otherwise
- `pr_impact` automatically benefits since it calls `query_trace()`
- Runtime PGQ failures silently fall back to CTE with debug logging

## Design Notes
- PGQ sets `depth=1` for all results (bounded traversal doesn't provide per-hop depth)
- PGQ uses `"references"` as generic relationship (multi-hop COLUMNS can't extract per-hop edge attributes)
- `exclude_edges` always forces CTE (PGQ doesn't support edge exclusion, used by pr_impact delta mode)

## Test Plan
| Scenario | Test | Status |
|----------|------|--------|
| trace_dependencies with DuckPGQ | `test_trace_deps_duckpgq` | passing |
| trace_dependencies CTE fallback | `test_trace_deps_cte_fallback` | passing |
| pr_impact multi-root DuckPGQ | `test_pr_impact_duckpgq_multi_root` | passing |
| pr_impact fallback | `test_pr_impact_cte_fallback` | passing |
| DuckPGQ and CTE parity | `test_trace_pgq_cte_parity` | passing |