### PR TITLE
feat-37-yaml-config

### DIFF
--- a/src/sqlprism/cli.py
+++ b/src/sqlprism/cli.py
@@ -73,7 +73,7 @@ def serve(config_path: str, db_path: str | None, transport: str, port: int):
             format="%(asctime)s %(levelname)s %(name)s: %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S",
         )
-    config = load_config(config_path)
+    config = _cli_load_config(config_path)
 
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
 
@@ -104,7 +104,7 @@ def reindex(config_path: str, db_path: str | None, repo_name: str | None):
     from sqlprism.core.graph import GraphDB
     from sqlprism.core.indexer import Indexer
 
-    config = load_config(config_path)
+    config = _cli_load_config(config_path)
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
 
     Path(effective_db_path).parent.mkdir(parents=True, exist_ok=True)
@@ -227,7 +227,7 @@ def reindex_file(paths, config_path, db_path):
     from sqlprism.core.graph import GraphDB
     from sqlprism.core.indexer import Indexer
 
-    config = load_config(config_path)
+    config = _cli_load_config(config_path)
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
 
     Path(effective_db_path).parent.mkdir(parents=True, exist_ok=True)
@@ -302,7 +302,7 @@ def reindex_sqlmesh(
     from sqlprism.core.graph import GraphDB
     from sqlprism.core.indexer import Indexer
 
-    config = load_config(config_path)
+    config = _cli_load_config(config_path)
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
     Path(effective_db_path).parent.mkdir(parents=True, exist_ok=True)
 
@@ -388,7 +388,7 @@ def reindex_dbt_cmd(
     from sqlprism.core.graph import GraphDB
     from sqlprism.core.indexer import Indexer
 
-    config = load_config(config_path)
+    config = _cli_load_config(config_path)
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
     Path(effective_db_path).parent.mkdir(parents=True, exist_ok=True)
 
@@ -426,7 +426,7 @@ def _open_graph(config_path: str, db_path: str | None):
     """Load config, resolve db_path, and return a GraphDB instance."""
     from sqlprism.core.graph import GraphDB
 
-    config = load_config(config_path)
+    config = _cli_load_config(config_path)
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
 
     if not Path(effective_db_path).exists():
@@ -600,7 +600,7 @@ def status(config_path: str, db_path: str | None):
     """Show current index status."""
     from sqlprism.core.graph import GraphDB
 
-    config = load_config(config_path)
+    config = _cli_load_config(config_path)
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
 
     if not Path(effective_db_path).exists():
@@ -624,12 +624,17 @@ def status(config_path: str, db_path: str | None):
 )
 def init_config(fmt: str):
     """Create a default config file in the working directory."""
-    ext = ".yml" if fmt == "yaml" else ".json"
-    config_file = Path.cwd() / f"sqlprism{ext}"
+    cwd = Path.cwd()
 
-    if config_file.exists():
-        click.echo(f"Config already exists at {config_file}")
-        return
+    # Check for any existing config variant to avoid shadowing
+    for name in _CONFIG_NAMES:
+        existing = cwd / name
+        if existing.exists():
+            click.echo(f"Config already exists at {existing}")
+            return
+
+    ext = ".yml" if fmt == "yaml" else ".json"
+    config_file = cwd / f"sqlprism{ext}"
 
     default_config = {
         "db_path": str(DEFAULT_DB_PATH),
@@ -700,6 +705,14 @@ def _build_repo_configs(config: dict) -> dict:
     return result
 
 
+def _cli_load_config(path: str | None) -> dict:
+    """CLI wrapper: converts FileNotFoundError to a friendly click error."""
+    try:
+        return load_config(path)
+    except FileNotFoundError as e:
+        raise click.ClickException(str(e)) from e
+
+
 def load_config(path: str | None = None) -> dict:
     """Load config from YAML or JSON file with automatic discovery.
 
@@ -744,16 +757,30 @@ def load_config(path: str | None = None) -> dict:
         "No config file found. Searched:\n"
         + "".join(f"  - {cwd / n}\n" for n in _CONFIG_NAMES)
         + f"  - {LEGACY_CONFIG_PATH}\n"
-        "Create one with: sqlprism init"
+        + "Create one with: sqlprism init"
     )
 
 
 def _parse_config_file(path: Path) -> dict:
     """Parse a YAML or JSON config file."""
-    text = path.read_text()
-    if path.suffix in (".yml", ".yaml"):
-        return yaml.safe_load(text) or {}
-    return json.loads(text)
+    suffix = path.suffix.lower()
+    if suffix not in (".yml", ".yaml", ".json"):
+        raise click.ClickException(
+            f"Unsupported config format: {path.suffix}. Use .yml, .yaml, or .json"
+        )
+    try:
+        text = path.read_text()
+        if suffix in (".yml", ".yaml"):
+            result = yaml.safe_load(text) or {}
+        else:
+            result = json.loads(text) if text.strip() else {}
+    except (yaml.YAMLError, json.JSONDecodeError, OSError) as e:
+        raise click.ClickException(f"Failed to parse {path}: {e}") from e
+    if not isinstance(result, dict):
+        raise click.ClickException(
+            f"Config must be a mapping, got {type(result).__name__} in {path}"
+        )
+    return result
 
 
 def main():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,3 +356,29 @@ def test_init_format_json_flag(tmp_path):
         assert "db_path" in config
         # YAML file should NOT exist
         assert not (Path.cwd() / "sqlprism.yml").exists()
+
+
+def test_init_does_not_overwrite_existing(tmp_path):
+    """Second init invocation does not overwrite and warns about existing config."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        # First run creates the file
+        runner.invoke(cli, ["init"])
+        yml_path = Path.cwd() / "sqlprism.yml"
+        original = yml_path.read_text()
+
+        # Second run detects existing config
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        assert "already exists" in result.output
+        assert yml_path.read_text() == original  # unchanged
+
+
+def test_init_detects_other_format(tmp_path):
+    """init --format json aborts if sqlprism.yml already exists."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        runner.invoke(cli, ["init"])  # creates sqlprism.yml
+        result = runner.invoke(cli, ["init", "--format", "json"])
+        assert "already exists" in result.output
+        assert not (Path.cwd() / "sqlprism.json").exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 
 import json
 
+import click
 import pytest
 import yaml
 
@@ -9,12 +10,21 @@ from sqlprism.cli import load_config
 
 
 def test_load_config_yaml_precedence(tmp_path, monkeypatch):
-    """YAML config takes precedence over JSON when both exist."""
-    yaml_cfg = {"db_path": "/from/yaml"}
-    json_cfg = {"db_path": "/from/json"}
+    """YAML .yml takes precedence over .yaml and .json."""
+    (tmp_path / "sqlprism.yml").write_text(yaml.dump({"db_path": "/from/yml"}))
+    (tmp_path / "sqlprism.yaml").write_text(yaml.dump({"db_path": "/from/yaml"}))
+    (tmp_path / "sqlprism.json").write_text(json.dumps({"db_path": "/from/json"}))
 
-    (tmp_path / "sqlprism.yml").write_text(yaml.dump(yaml_cfg))
-    (tmp_path / "sqlprism.json").write_text(json.dumps(json_cfg))
+    monkeypatch.chdir(tmp_path)
+
+    result = load_config()
+    assert result["db_path"] == "/from/yml"
+
+
+def test_load_config_yaml_extension_variant(tmp_path, monkeypatch):
+    """sqlprism.yaml is discovered when .yml is absent."""
+    (tmp_path / "sqlprism.yaml").write_text(yaml.dump({"db_path": "/from/yaml"}))
+    (tmp_path / "sqlprism.json").write_text(json.dumps({"db_path": "/from/json"}))
 
     monkeypatch.chdir(tmp_path)
 
@@ -24,8 +34,7 @@ def test_load_config_yaml_precedence(tmp_path, monkeypatch):
 
 def test_load_config_json_fallback(tmp_path, monkeypatch):
     """JSON config is discovered when no YAML variants exist."""
-    json_cfg = {"db_path": "/from/json"}
-    (tmp_path / "sqlprism.json").write_text(json.dumps(json_cfg))
+    (tmp_path / "sqlprism.json").write_text(json.dumps({"db_path": "/from/json"}))
 
     monkeypatch.chdir(tmp_path)
 
@@ -37,27 +46,34 @@ def test_load_config_legacy_location(tmp_path, monkeypatch):
     """Legacy ~/.sqlprism/config.json is used when cwd has no config."""
     legacy_path = tmp_path / "legacy" / "config.json"
     legacy_path.parent.mkdir(parents=True)
-    legacy_cfg = {"db_path": "/from/legacy"}
-    legacy_path.write_text(json.dumps(legacy_cfg))
+    legacy_path.write_text(json.dumps({"db_path": "/from/legacy"}))
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("sqlprism.cli.LEGACY_CONFIG_PATH", legacy_path)
+
+    # Verify cwd is clean
+    assert not (tmp_path / "sqlprism.yml").exists()
 
     result = load_config()
     assert result["db_path"] == "/from/legacy"
 
 
 def test_load_config_explicit_path(tmp_path):
-    """Explicit path bypasses discovery; missing path raises FileNotFoundError."""
-    custom_dir = tmp_path / "custom"
-    custom_dir.mkdir()
-    custom_file = custom_dir / "my.yml"
-    custom_file.write_text(yaml.dump({"db_path": "/from/custom"}))
+    """Explicit path bypasses discovery."""
+    # YAML explicit path
+    yml_file = tmp_path / "custom.yml"
+    yml_file.write_text(yaml.dump({"db_path": "/from/yml"}))
+    assert load_config(path=str(yml_file))["db_path"] == "/from/yml"
 
-    result = load_config(path=str(custom_file))
-    assert result["db_path"] == "/from/custom"
+    # JSON explicit path
+    json_file = tmp_path / "custom.json"
+    json_file.write_text(json.dumps({"db_path": "/from/json"}))
+    assert load_config(path=str(json_file))["db_path"] == "/from/json"
 
-    with pytest.raises(FileNotFoundError):
+
+def test_load_config_explicit_path_missing():
+    """Missing explicit path raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError, match="Config file not found"):
         load_config(path="nonexistent.yml")
 
 
@@ -76,8 +92,21 @@ def test_yaml_json_schema_parity(tmp_path):
     """Same config structure produces identical dicts from YAML and JSON."""
     config = {
         "db_path": "/shared/graph.duckdb",
-        "repos": {"warehouse": {"path": "/data/warehouse"}},
         "sql_dialect": "postgres",
+        "repos": {"warehouse": {"path": "/data/warehouse"}},
+        "dbt_repos": {
+            "my-dbt": {
+                "project_path": "/path/to/dbt",
+                "target": "dev",
+                "dialect": "starrocks",
+            }
+        },
+        "sqlmesh_repos": {
+            "my-sm": {
+                "project_path": "/path/to/sqlmesh",
+                "variables": {"GRACE_PERIOD": 7},
+            }
+        },
     }
 
     yaml_file = tmp_path / "config.yml"
@@ -89,3 +118,49 @@ def test_yaml_json_schema_parity(tmp_path):
     from_json = load_config(path=str(json_file))
 
     assert from_yaml == from_json
+
+
+def test_load_config_malformed_yaml(tmp_path):
+    """Malformed YAML raises ClickException."""
+    bad = tmp_path / "bad.yml"
+    bad.write_text("repos: {invalid: [}")
+    with pytest.raises(click.ClickException, match="Failed to parse"):
+        load_config(path=str(bad))
+
+
+def test_load_config_malformed_json(tmp_path):
+    """Malformed JSON raises ClickException."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{invalid json")
+    with pytest.raises(click.ClickException, match="Failed to parse"):
+        load_config(path=str(bad))
+
+
+def test_load_config_empty_yaml(tmp_path):
+    """Empty YAML file returns empty dict."""
+    empty = tmp_path / "empty.yml"
+    empty.write_text("")
+    assert load_config(path=str(empty)) == {}
+
+
+def test_load_config_empty_json(tmp_path):
+    """Empty JSON file returns empty dict."""
+    empty = tmp_path / "empty.json"
+    empty.write_text("")
+    assert load_config(path=str(empty)) == {}
+
+
+def test_load_config_non_dict_yaml(tmp_path):
+    """YAML file with non-dict content raises ClickException."""
+    scalar = tmp_path / "scalar.yml"
+    scalar.write_text("just a string")
+    with pytest.raises(click.ClickException, match="Config must be a mapping"):
+        load_config(path=str(scalar))
+
+
+def test_load_config_unsupported_extension(tmp_path):
+    """Unsupported extension raises ClickException."""
+    toml = tmp_path / "config.toml"
+    toml.write_text("[repos]")
+    with pytest.raises(click.ClickException, match="Unsupported config format"):
+        load_config(path=str(toml))


### PR DESCRIPTION
Closes #37

## Summary
- Add `load_config()` with auto-discovery: `sqlprism.yml` > `sqlprism.yaml` > `sqlprism.json` > `~/.sqlprism/config.json`
- Explicit path overrides discovery; `FileNotFoundError` when nothing found
- `sqlprism init` generates YAML by default; `--format json` for JSON
- All CLI commands use `None` default for config path (auto-discovery)
- pyyaml was already a dependency

## Test Plan
| Scenario | Test | Status |
|----------|------|--------|
| YAML discovered first | `test_load_config_yaml_precedence` | :white_check_mark: |
| JSON fallback | `test_load_config_json_fallback` | :white_check_mark: |
| Legacy location fallback | `test_load_config_legacy_location` | :white_check_mark: |
| Explicit path | `test_load_config_explicit_path` | :white_check_mark: |
| init generates YAML | `test_init_generates_yaml` | :white_check_mark: |
| init --format json | `test_init_format_json_flag` | :white_check_mark: |
| No config found | `test_load_config_not_found` | :white_check_mark: |
| Schema parity | `test_yaml_json_schema_parity` | :white_check_mark: |