### PR TITLE
chore-61-conventions-semantic-tags-schema

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -60,6 +60,9 @@ CREATE SEQUENCE IF NOT EXISTS seq_node_id START 1;
 CREATE SEQUENCE IF NOT EXISTS seq_edge_id START 1;
 CREATE SEQUENCE IF NOT EXISTS seq_usage_id START 1;
 CREATE SEQUENCE IF NOT EXISTS seq_lineage_id START 1;
+CREATE SEQUENCE IF NOT EXISTS seq_column_id START 1;
+CREATE SEQUENCE IF NOT EXISTS seq_convention_id START 1;
+CREATE SEQUENCE IF NOT EXISTS seq_tag_id START 1;
 
 CREATE TABLE IF NOT EXISTS repos (
     repo_id     INTEGER PRIMARY KEY DEFAULT nextval('seq_repo_id'),
@@ -126,8 +129,6 @@ CREATE TABLE IF NOT EXISTS column_lineage (
     hop_expression  TEXT
 );
 
-CREATE SEQUENCE IF NOT EXISTS seq_column_id START 1;
-
 CREATE TABLE IF NOT EXISTS columns (
     column_id   INTEGER PRIMARY KEY DEFAULT nextval('seq_column_id'),
     node_id     INTEGER NOT NULL,
@@ -139,30 +140,27 @@ CREATE TABLE IF NOT EXISTS columns (
     UNIQUE(node_id, column_name)
 );
 
-CREATE SEQUENCE IF NOT EXISTS seq_convention_id START 1;
-
 CREATE TABLE IF NOT EXISTS conventions (
     convention_id INTEGER PRIMARY KEY DEFAULT nextval('seq_convention_id'),
     repo_id       INTEGER NOT NULL,   -- logical FK to repos(repo_id)
     layer         TEXT NOT NULL,
-    convention_type TEXT NOT NULL,     -- 'naming' | 'references' | 'required_columns' | 'column_style'
+    convention_type TEXT NOT NULL
+        CHECK (convention_type IN ('naming', 'references', 'required_columns', 'column_style')),
     payload       JSON NOT NULL,
-    confidence    FLOAT NOT NULL,
-    source        TEXT NOT NULL,       -- 'inferred' | 'override'
+    confidence    FLOAT NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    source        TEXT NOT NULL CHECK (source IN ('inferred', 'override')),
     model_count   INTEGER NOT NULL,
     UNIQUE(repo_id, layer, convention_type)
 );
-
-CREATE SEQUENCE IF NOT EXISTS seq_tag_id START 1;
 
 CREATE TABLE IF NOT EXISTS semantic_tags (
     tag_id     INTEGER PRIMARY KEY DEFAULT nextval('seq_tag_id'),
     repo_id    INTEGER NOT NULL,      -- logical FK to repos(repo_id)
     tag_name   TEXT NOT NULL,
     node_id    INTEGER NOT NULL,      -- logical FK to nodes(node_id)
-    confidence FLOAT NOT NULL,
-    source     TEXT NOT NULL,         -- 'inferred' | 'anchor' | 'explicit'
-    UNIQUE(repo_id, tag_name, node_id)
+    confidence FLOAT NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    source     TEXT NOT NULL CHECK (source IN ('inferred', 'anchor', 'explicit')),
+    UNIQUE(tag_name, node_id)
 );
 
 """
@@ -186,6 +184,7 @@ CREATE INDEX IF NOT EXISTS idx_nodes_schema ON nodes(schema);
 CREATE INDEX IF NOT EXISTS idx_columns_node ON columns(node_id);
 CREATE INDEX IF NOT EXISTS idx_columns_name ON columns(column_name);
 CREATE INDEX IF NOT EXISTS idx_conventions_repo ON conventions(repo_id);
+CREATE INDEX IF NOT EXISTS idx_conventions_type ON conventions(convention_type);
 CREATE INDEX IF NOT EXISTS idx_tags_name ON semantic_tags(tag_name);
 CREATE INDEX IF NOT EXISTS idx_tags_node ON semantic_tags(node_id);
 CREATE INDEX IF NOT EXISTS idx_tags_repo ON semantic_tags(repo_id);

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1895,7 +1895,7 @@ def test_column_def_null_data_type_returns_text():
 
 
 def test_conventions_table_exists():
-    """conventions table is created on database init."""
+    """conventions table is created on database init with correct types."""
     from sqlprism.core.graph import GraphDB
 
     db = GraphDB()
@@ -1904,19 +1904,19 @@ def test_conventions_table_exists():
         "WHERE table_name = 'conventions' ORDER BY ordinal_position"
     ).fetchall()
     col_map = {r[0]: r[1] for r in rows}
-    assert "convention_id" in col_map
-    assert "repo_id" in col_map
-    assert "layer" in col_map
-    assert "convention_type" in col_map
-    assert "payload" in col_map
-    assert "confidence" in col_map
-    assert "source" in col_map
-    assert "model_count" in col_map
+    assert col_map["convention_id"] == "INTEGER"
+    assert col_map["repo_id"] == "INTEGER"
+    assert col_map["layer"] == "VARCHAR"
+    assert col_map["convention_type"] == "VARCHAR"
+    assert col_map["payload"] == "JSON"
+    assert col_map["confidence"] == "FLOAT"
+    assert col_map["source"] == "VARCHAR"
+    assert col_map["model_count"] == "INTEGER"
     db.close()
 
 
 def test_semantic_tags_table_exists():
-    """semantic_tags table is created on database init."""
+    """semantic_tags table is created on database init with correct types."""
     from sqlprism.core.graph import GraphDB
 
     db = GraphDB()
@@ -1925,12 +1925,12 @@ def test_semantic_tags_table_exists():
         "WHERE table_name = 'semantic_tags' ORDER BY ordinal_position"
     ).fetchall()
     col_map = {r[0]: r[1] for r in rows}
-    assert "tag_id" in col_map
-    assert "repo_id" in col_map
-    assert "tag_name" in col_map
-    assert "node_id" in col_map
-    assert "confidence" in col_map
-    assert "source" in col_map
+    assert col_map["tag_id"] == "INTEGER"
+    assert col_map["repo_id"] == "INTEGER"
+    assert col_map["tag_name"] == "VARCHAR"
+    assert col_map["node_id"] == "INTEGER"
+    assert col_map["confidence"] == "FLOAT"
+    assert col_map["source"] == "VARCHAR"
     db.close()
 
 
@@ -1944,15 +1944,15 @@ def test_schema_migration_preserves_data():
     file_id = db.insert_file(repo_id, "model.sql", "sql", "abc123")
     node_id = db.insert_node(file_id, "table", "orders", "sql", 1, 10, schema="public")
 
-    # Verify existing data still accessible
+    # Verify existing data still accessible across multiple tables
     result = db.conn.execute("SELECT name FROM nodes WHERE node_id = ?", [node_id]).fetchone()
     assert result[0] == "orders"
+    assert db.conn.execute("SELECT COUNT(*) FROM repos").fetchone()[0] == 1
+    assert db.conn.execute("SELECT COUNT(*) FROM files").fetchone()[0] == 1
 
     # Verify new tables exist and are empty
-    conv_count = db.conn.execute("SELECT COUNT(*) FROM conventions").fetchone()[0]
-    tag_count = db.conn.execute("SELECT COUNT(*) FROM semantic_tags").fetchone()[0]
-    assert conv_count == 0
-    assert tag_count == 0
+    assert db.conn.execute("SELECT COUNT(*) FROM conventions").fetchone()[0] == 0
+    assert db.conn.execute("SELECT COUNT(*) FROM semantic_tags").fetchone()[0] == 0
     db.close()
 
 
@@ -1965,7 +1965,7 @@ def test_convention_id_auto_increment():
     file_id = db.insert_file(repo_id, "model.sql", "sql", "abc123")
     node_id = db.insert_node(file_id, "table", "orders", "sql", 1, 10, schema="public")
 
-    # Insert conventions
+    # Insert conventions — IDs should be 1 and 2 in fresh DB
     db.conn.execute(
         "INSERT INTO conventions (repo_id, layer, convention_type, payload, confidence, source, model_count) "
         "VALUES (?, 'staging', 'naming', '{\"pattern\": \"stg_{entity}\"}', 0.9, 'inferred', 10)",
@@ -1977,31 +1977,108 @@ def test_convention_id_auto_increment():
         [repo_id],
     )
     ids = db.conn.execute("SELECT convention_id FROM conventions ORDER BY convention_id").fetchall()
-    assert ids[0][0] < ids[1][0]  # auto-incrementing
+    assert ids == [(1,), (2,)]
 
-    # Insert semantic tags
+    # Insert semantic tag — ID should be 1 in fresh DB
     db.conn.execute(
         "INSERT INTO semantic_tags (repo_id, tag_name, node_id, confidence, source) "
         "VALUES (?, 'customer', ?, 0.85, 'inferred')",
         [repo_id, node_id],
     )
     tag_id = db.conn.execute("SELECT tag_id FROM semantic_tags").fetchone()[0]
-    assert tag_id >= 1
+    assert tag_id == 1
+    db.close()
 
-    # Verify unique constraint on conventions
-    with pytest.raises(Exception):
+
+def test_conventions_unique_constraints():
+    """Unique constraints prevent duplicate conventions and tags."""
+    import duckdb
+
+    from sqlprism.core.graph import GraphDB
+
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test")
+    file_id = db.insert_file(repo_id, "model.sql", "sql", "abc123")
+    node_id = db.insert_node(file_id, "table", "orders", "sql", 1, 10, schema="public")
+
+    # Insert initial rows
+    db.conn.execute(
+        "INSERT INTO conventions (repo_id, layer, convention_type, payload, confidence, source, model_count) "
+        "VALUES (?, 'staging', 'naming', '{\"pattern\": \"stg_{entity}\"}', 0.9, 'inferred', 10)",
+        [repo_id],
+    )
+    db.conn.execute(
+        "INSERT INTO semantic_tags (repo_id, tag_name, node_id, confidence, source) "
+        "VALUES (?, 'customer', ?, 0.85, 'inferred')",
+        [repo_id, node_id],
+    )
+
+    # Duplicate convention (same repo_id, layer, convention_type) must fail
+    with pytest.raises(duckdb.ConstraintException):
         db.conn.execute(
             "INSERT INTO conventions (repo_id, layer, convention_type, payload, confidence, source, model_count) "
             "VALUES (?, 'staging', 'naming', '{}', 0.5, 'override', 10)",
             [repo_id],
         )
 
-    # Verify unique constraint on semantic_tags
-    with pytest.raises(Exception):
+    # Duplicate tag (same tag_name, node_id) must fail
+    with pytest.raises(duckdb.ConstraintException):
         db.conn.execute(
             "INSERT INTO semantic_tags (repo_id, tag_name, node_id, confidence, source) "
             "VALUES (?, 'customer', ?, 0.9, 'explicit')",
             [repo_id, node_id],
         )
+    db.close()
 
+
+def test_conventions_check_constraints():
+    """CHECK constraints enforce valid confidence range and enum values."""
+    import duckdb
+
+    from sqlprism.core.graph import GraphDB
+
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test")
+    file_id = db.insert_file(repo_id, "model.sql", "sql", "abc123")
+    node_id = db.insert_node(file_id, "table", "orders", "sql", 1, 10, schema="public")
+
+    # Confidence out of range on conventions
+    with pytest.raises(duckdb.ConstraintException):
+        db.conn.execute(
+            "INSERT INTO conventions (repo_id, layer, convention_type, payload, confidence, source, model_count) "
+            "VALUES (?, 'staging', 'naming', '{}', 1.5, 'inferred', 10)",
+            [repo_id],
+        )
+
+    # Invalid convention_type
+    with pytest.raises(duckdb.ConstraintException):
+        db.conn.execute(
+            "INSERT INTO conventions (repo_id, layer, convention_type, payload, confidence, source, model_count) "
+            "VALUES (?, 'staging', 'invalid_type', '{}', 0.5, 'inferred', 10)",
+            [repo_id],
+        )
+
+    # Invalid source on conventions
+    with pytest.raises(duckdb.ConstraintException):
+        db.conn.execute(
+            "INSERT INTO conventions (repo_id, layer, convention_type, payload, confidence, source, model_count) "
+            "VALUES (?, 'staging', 'naming', '{}', 0.5, 'bad_source', 10)",
+            [repo_id],
+        )
+
+    # Confidence out of range on semantic_tags
+    with pytest.raises(duckdb.ConstraintException):
+        db.conn.execute(
+            "INSERT INTO semantic_tags (repo_id, tag_name, node_id, confidence, source) "
+            "VALUES (?, 'customer', ?, -0.1, 'inferred')",
+            [repo_id, node_id],
+        )
+
+    # Invalid source on semantic_tags
+    with pytest.raises(duckdb.ConstraintException):
+        db.conn.execute(
+            "INSERT INTO semantic_tags (repo_id, tag_name, node_id, confidence, source) "
+            "VALUES (?, 'customer', ?, 0.5, 'bad_source')",
+            [repo_id, node_id],
+        )
     db.close()


### PR DESCRIPTION
Closes #61

## Summary
- Add `conventions` table — stores inferred/override conventions per layer (naming, references, required_columns, column_style)
- Add `semantic_tags` table — stores model-to-tag assignments with confidence scoring
- Sequences, indexes, and unique constraints for both tables
- Foundation for all v1.2 Convention Engine + Semantic Tags features

## Test Plan

| Scenario | Test | Status |
|----------|------|--------|
| conventions table created | `test_conventions_table_exists` | :white_check_mark: |
| semantic_tags table created | `test_semantic_tags_table_exists` | :white_check_mark: |
| Tables alongside existing schema | `test_schema_migration_preserves_data` | :white_check_mark: |
| Auto-increment sequences + unique constraints | `test_convention_id_auto_increment` | :white_check_mark: |