### PR TITLE
feat-64-convention-storage-reindex-hook

### DIFF
--- a/src/sqlprism/core/conventions.py
+++ b/src/sqlprism/core/conventions.py
@@ -103,71 +103,74 @@ class ConventionEngine:
         ref_rules_by_layer = {r.source_layer: r for r in reference_rules}
 
         stored = 0
-        for layer in layers:
-            # Step 2: Naming pattern
-            naming = self.infer_naming_pattern(layer.model_names)
-            self._store_convention(
-                layer.name,
-                "naming",
-                {
-                    "pattern": naming.pattern,
-                    "matching_count": naming.matching_count,
-                    "total_count": naming.total_count,
-                    "exceptions": naming.exceptions,
-                },
-                naming.confidence,
-                layer.model_count,
-            )
-            stored += 1
-
-            # Step 3: Reference rules
-            ref_rule = ref_rules_by_layer.get(layer.name)
-            if ref_rule:
+        # Wrap all upserts in a single transaction for atomicity —
+        # partial state on crash is avoided.
+        with self.db.write_transaction():
+            for layer in layers:
+                # Step 2: Naming pattern
+                naming = self.infer_naming_pattern(layer.model_names)
                 self._store_convention(
                     layer.name,
-                    "references",
+                    "naming",
                     {
-                        "allowed_targets": ref_rule.allowed_targets,
-                        "target_distribution": ref_rule.target_distribution,
+                        "pattern": naming.pattern,
+                        "matching_count": naming.matching_count,
+                        "total_count": naming.total_count,
+                        "exceptions": naming.exceptions,
                     },
-                    ref_rule.confidence,
+                    naming.confidence,
                     layer.model_count,
                 )
                 stored += 1
 
-            # Step 4: Common columns
-            common_cols = self.infer_common_columns(layer)
-            if common_cols:
-                self._store_convention(
-                    layer.name,
-                    "required_columns",
-                    {
-                        "columns": [
-                            {
-                                "name": c.column_name,
-                                "frequency": c.frequency,
-                                "source": c.source,
-                                "missing_in": c.missing_in,
-                            }
-                            for c in common_cols
-                        ]
-                    },
-                    max(c.frequency for c in common_cols),
-                    layer.model_count,
-                )
-                stored += 1
+                # Step 3: Reference rules
+                ref_rule = ref_rules_by_layer.get(layer.name)
+                if ref_rule:
+                    self._store_convention(
+                        layer.name,
+                        "references",
+                        {
+                            "allowed_targets": ref_rule.allowed_targets,
+                            "target_distribution": ref_rule.target_distribution,
+                        },
+                        ref_rule.confidence,
+                        layer.model_count,
+                    )
+                    stored += 1
 
-            # Step 5: Column style
-            style = self.detect_column_style(layer)
-            if style.confidence > 0.0:
-                self._store_convention(
-                    layer.name,
-                    "column_style",
-                    {"style": style.style},
-                    style.confidence,
-                    layer.model_count,
-                )
-                stored += 1
+                # Step 4: Common columns
+                common_cols = self.infer_common_columns(layer)
+                if common_cols:
+                    self._store_convention(
+                        layer.name,
+                        "required_columns",
+                        {
+                            "columns": [
+                                {
+                                    "name": c.column_name,
+                                    "frequency": c.frequency,
+                                    "source": c.source,
+                                    "missing_in": c.missing_in,
+                                }
+                                for c in common_cols
+                            ]
+                        },
+                        min(max(c.frequency for c in common_cols), 1.0),
+                        layer.model_count,
+                    )
+                    stored += 1
+
+                # Step 5: Column style
+                style = self.detect_column_style(layer)
+                if style.confidence > 0.0:
+                    self._store_convention(
+                        layer.name,
+                        "column_style",
+                        {"style": style.style},
+                        min(style.confidence, 1.0),
+                        layer.model_count,
+                    )
+                    stored += 1
 
         logger.info(
             "Convention inference: %d layers, %d conventions stored",
@@ -187,27 +190,32 @@ class ConventionEngine:
         confidence: float,
         model_count: int,
     ) -> None:
-        """Upsert a convention into the conventions table."""
-        with self.db._write_lock:
-            self.db._execute_write(
-                "INSERT INTO conventions "
-                "(repo_id, layer, convention_type, payload, "
-                "confidence, source, model_count) "
-                "VALUES (?, ?, ?, ?, ?, 'inferred', ?) "
-                "ON CONFLICT (repo_id, layer, convention_type) "
-                "DO UPDATE SET "
-                "payload = EXCLUDED.payload, "
-                "confidence = EXCLUDED.confidence, "
-                "model_count = EXCLUDED.model_count",
-                [
-                    self.repo_id,
-                    layer,
-                    convention_type,
-                    json.dumps(payload),
-                    confidence,
-                    model_count,
-                ],
-            )
+        """Upsert a convention into the conventions table.
+
+        Skips rows with ``source='override'`` — explicit overrides
+        are preserved and not clobbered by inference.
+        Must be called inside ``write_transaction()``.
+        """
+        self.db._execute_write(
+            "INSERT INTO conventions "
+            "(repo_id, layer, convention_type, payload, "
+            "confidence, source, model_count) "
+            "VALUES (?, ?, ?, ?, ?, 'inferred', ?) "
+            "ON CONFLICT (repo_id, layer, convention_type) "
+            "DO UPDATE SET "
+            "payload = EXCLUDED.payload, "
+            "confidence = EXCLUDED.confidence, "
+            "model_count = EXCLUDED.model_count "
+            "WHERE conventions.source != 'override'",
+            [
+                self.repo_id,
+                layer,
+                convention_type,
+                json.dumps(payload),
+                min(confidence, 1.0),
+                model_count,
+            ],
+        )
 
     def detect_layers(self) -> list[Layer]:
         """Detect layers from directory structure.
@@ -523,7 +531,7 @@ class ConventionEngine:
         ).fetchall()
 
         def_freq: dict[str, float] = {
-            col: count / model_count for col, count in def_rows
+            col: min(count / model_count, 1.0) for col, count in def_rows
         }
 
         # Columns from usage (column_usage table, SELECT only)
@@ -546,7 +554,7 @@ class ConventionEngine:
         ).fetchall()
 
         usage_freq: dict[str, float] = {
-            col: count / model_count for col, count in usage_rows
+            col: min(count / model_count, 1.0) for col, count in usage_rows
         }
 
         # Merge: definition is more authoritative

--- a/src/sqlprism/core/indexer.py
+++ b/src/sqlprism/core/indexer.py
@@ -702,7 +702,7 @@ class Indexer:
                 repo_id,
                 e,
             )
-            return {}
+            return {"layers_detected": 0, "conventions_stored": 0}
 
     def _insert_parse_result(
         self,

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -790,8 +790,8 @@ def test_conventions_computed_after_reindex():
         engine = ConventionEngine(db, repo_id)
         result = engine.run_inference()
 
-        assert result["layers_detected"] >= 2
-        assert result["conventions_stored"] > 0
+        assert result["layers_detected"] == 3  # raw, staging, marts
+        assert result["conventions_stored"] >= 4  # at least naming per layer + refs + cols
 
         # Verify conventions table has entries
         rows = db.conn.execute(
@@ -799,7 +799,7 @@ def test_conventions_computed_after_reindex():
             "FROM conventions WHERE repo_id = ? ORDER BY layer, convention_type",
             [repo_id],
         ).fetchall()
-        assert len(rows) > 0
+        assert len(rows) >= 4
 
         # Check naming convention stored for staging
         staging_naming = next(
@@ -808,6 +808,7 @@ def test_conventions_computed_after_reindex():
         )
         assert staging_naming is not None
         assert staging_naming[3] == "inferred"  # source
+        assert staging_naming[2] > 0  # confidence > 0
     finally:
         db.close()
 
@@ -851,13 +852,23 @@ def test_conventions_payload_is_valid_json():
         engine.run_inference()
 
         rows = db.conn.execute(
-            "SELECT payload FROM conventions WHERE repo_id = ?",
+            "SELECT convention_type, payload FROM conventions WHERE repo_id = ?",
             [repo_id],
         ).fetchall()
 
-        for (payload,) in rows:
+        expected_keys = {
+            "naming": "pattern",
+            "references": "allowed_targets",
+            "required_columns": "columns",
+            "column_style": "style",
+        }
+        for conv_type, payload in rows:
             parsed = json.loads(payload)
             assert isinstance(parsed, dict)
+            assert len(parsed) > 0
+            # Verify required key per convention type
+            if conv_type in expected_keys:
+                assert expected_keys[conv_type] in parsed
     finally:
         db.close()
 


### PR DESCRIPTION
Closes #64

## Summary
- `ConventionEngine.run_inference()`: runs all 5 inference steps per layer and upserts results into the `conventions` table
- `_store_convention()`: ON CONFLICT DO UPDATE for idempotent upserts
- Reindex hook: `_run_convention_inference()` called in `reindex_repo`, `reindex_dbt`, `reindex_sqlmesh` (non-fatal)
- Stores naming, references, required_columns, column_style as JSON payloads

## Test Plan

| Scenario | Test | Status |
|----------|------|--------|
| Conventions after full reindex | `test_conventions_computed_after_reindex` | :white_check_mark: |
| Upsert not duplicate | `test_conventions_upsert_on_rerun` | :white_check_mark: |
| Valid JSON payloads | `test_conventions_payload_is_valid_json` | :white_check_mark: |
| Empty repo | `test_run_inference_empty_repo` | :white_check_mark: |