### PR TITLE
feat-67-conventions-cli

### DIFF
--- a/src/sqlprism/cli.py
+++ b/src/sqlprism/cli.py
@@ -633,7 +633,7 @@ def conventions_init(config_path: str, db_path: str | None, force: bool):
     from sqlprism.core.conventions import ConventionEngine
     from sqlprism.core.graph import GraphDB
 
-    config = _cli_load_config(config_path)
+    config = _try_load_config(config_path)
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
 
     if not Path(effective_db_path).exists():
@@ -655,8 +655,13 @@ def conventions_init(config_path: str, db_path: str | None, force: bool):
             click.echo("No repos indexed. Run 'sqlprism reindex' first.")
             sys.exit(1)
 
-        # Use the first repo (most common case: single repo)
         repo_id = repos[0][0]
+        if len(repos) > 1:
+            click.echo(
+                f"Warning: {len(repos)} repos found; using first repo. "
+                "Use 'conventions refresh' to process all repos.",
+                err=True,
+            )
         engine = ConventionEngine(graph, repo_id)
         engine.run_inference()
 
@@ -679,7 +684,7 @@ def conventions_refresh(config_path: str, db_path: str | None):
     from sqlprism.core.conventions import ConventionEngine
     from sqlprism.core.graph import GraphDB
 
-    config = _cli_load_config(config_path)
+    config = _try_load_config(config_path)
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
 
     if not Path(effective_db_path).exists():
@@ -724,7 +729,7 @@ def conventions_diff(config_path: str, db_path: str | None, yaml_file: str):
     from sqlprism.core.conventions import ConventionEngine
     from sqlprism.core.graph import GraphDB
 
-    config = _cli_load_config(config_path)
+    config = _try_load_config(config_path)
     effective_db_path = db_path or config.get("db_path", str(DEFAULT_DB_PATH))
 
     if not Path(effective_db_path).exists():
@@ -739,6 +744,11 @@ def conventions_diff(config_path: str, db_path: str | None, yaml_file: str):
             sys.exit(1)
 
         repo_id = repos[0][0]
+        if len(repos) > 1:
+            click.echo(
+                f"Warning: {len(repos)} repos found; comparing first repo only.",
+                err=True,
+            )
         engine = ConventionEngine(graph, repo_id)
         diff_output = engine.get_diff(yaml_file)
         click.echo(diff_output)
@@ -835,6 +845,18 @@ def _build_repo_configs(config: dict) -> dict:
         else:
             result[name] = {"path": cfg, "repo_type": "sqlmesh"}
     return result
+
+
+def _try_load_config(path: str | None) -> dict:
+    """Try to load config, return empty dict if not found.
+
+    Unlike ``_cli_load_config``, does not raise on missing config.
+    Used by commands that work with just ``--db`` and no config.
+    """
+    try:
+        return load_config(path)
+    except FileNotFoundError:
+        return {}
 
 
 def _cli_load_config(path: str | None) -> dict:

--- a/src/sqlprism/core/conventions.py
+++ b/src/sqlprism/core/conventions.py
@@ -318,7 +318,7 @@ class ConventionEngine:
                 parsed = json.loads(payload) if isinstance(payload, str) else payload
                 style = parsed.get("style", "")
                 lines.append(
-                    f"    column_style: {style}"
+                    f'    column_style: "{style}"'
                     f"  # confidence: {conf:.2f}"
                 )
 
@@ -329,7 +329,8 @@ class ConventionEngine:
     def get_diff(self, yaml_path: str | Path) -> str:
         """Compare current conventions against a YAML file.
 
-        Returns a human-readable diff showing changes.
+        Reports only actual differences: new/removed layers,
+        changed naming patterns, changed references, etc.
         """
         yaml_path = Path(yaml_path)
         if not yaml_path.is_file():
@@ -345,8 +346,7 @@ class ConventionEngine:
         # Get current conventions from DB
         rows = self.db._execute_read(
             "SELECT layer, convention_type, payload, confidence "
-            "FROM conventions WHERE repo_id = ? "
-            "ORDER BY layer, convention_type",
+            "FROM conventions WHERE repo_id = ?",
             [self.repo_id],
         ).fetchall()
 
@@ -360,7 +360,7 @@ class ConventionEngine:
 
         changes: list[str] = []
 
-        # New layers
+        # New/removed layers
         current_layers = set(current)
         yaml_layers = set(existing_convs)
         for layer in sorted(current_layers - yaml_layers):
@@ -368,23 +368,44 @@ class ConventionEngine:
         for layer in sorted(yaml_layers - current_layers):
             changes.append(f"- Removed layer: {layer}")
 
-        # Changed conventions
+        # Changed conventions in shared layers
         for layer in sorted(current_layers & yaml_layers):
             curr = current.get(layer, {})
-            # Check naming changes
-            if "naming" in curr:
-                curr_pattern = curr["naming"]["payload"].get("pattern", "")
-                yaml_naming = existing_convs.get(layer, {}).get("naming", "")
-                if curr_pattern != yaml_naming:
-                    changes.append(
-                        f"  {layer}.naming: "
-                        f'"{yaml_naming}" -> "{curr_pattern}"'
-                    )
-            # Check confidence changes
-            for conv_type, data in curr.items():
-                conf = data["confidence"]
+            yaml_layer = existing_convs.get(layer, {})
+
+            # Naming: compare DB pattern vs YAML naming string
+            curr_naming = curr.get("naming", {}).get("payload", {}).get("pattern", "")
+            yaml_naming = yaml_layer.get("naming", "")
+            if curr_naming and not yaml_naming:
+                changes.append(f"+ {layer}.naming: \"{curr_naming}\"")
+            elif yaml_naming and not curr_naming:
+                changes.append(f"- {layer}.naming: \"{yaml_naming}\"")
+            elif curr_naming != yaml_naming:
                 changes.append(
-                    f"  {layer}.{conv_type}: confidence {conf:.2f}"
+                    f"  {layer}.naming: "
+                    f"\"{yaml_naming}\" -> \"{curr_naming}\""
+                )
+
+            # References: compare allowed_refs lists
+            curr_refs = curr.get("references", {}).get("payload", {}).get("allowed_targets", [])
+            yaml_refs = yaml_layer.get("allowed_refs", [])
+            if sorted(curr_refs) != sorted(yaml_refs):
+                if curr_refs and not yaml_refs:
+                    changes.append(f"+ {layer}.allowed_refs: {curr_refs}")
+                elif yaml_refs and not curr_refs:
+                    changes.append(f"- {layer}.allowed_refs: {yaml_refs}")
+                else:
+                    changes.append(
+                        f"  {layer}.allowed_refs: {yaml_refs} -> {curr_refs}"
+                    )
+
+            # Column style
+            curr_style = curr.get("column_style", {}).get("payload", {}).get("style", "")
+            yaml_style = yaml_layer.get("column_style", "")
+            if curr_style != yaml_style and (curr_style or yaml_style):
+                changes.append(
+                    f"  {layer}.column_style: "
+                    f"\"{yaml_style}\" -> \"{curr_style}\""
                 )
 
         if not changes:

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -1272,8 +1272,38 @@ conventions:
 # ── Bootstrap CLI (generate_yaml, get_diff) ──
 
 
+def _create_test_db(tmp_path) -> Path:
+    """Create a temp DuckDB with a layered repo and conventions."""
+    db_path = tmp_path / "test.duckdb"
+    db = GraphDB(str(db_path))
+    try:
+        repo_id = db.upsert_repo("test", str(tmp_path))
+        models = [
+            ("models/raw/raw_orders.sql", "raw_orders"),
+            ("models/raw/raw_payments.sql", "raw_payments"),
+            ("models/staging/stg_orders.sql", "stg_orders"),
+            ("models/staging/stg_payments.sql", "stg_payments"),
+            ("models/staging/stg_customers.sql", "stg_customers"),
+            ("models/marts/revenue.sql", "revenue"),
+            ("models/marts/customers.sql", "customers"),
+        ]
+        nodes = {}
+        for i, (path, name) in enumerate(models):
+            fid = db.insert_file(repo_id, path, "sql", f"ck_{i}")
+            nid = db.insert_node(fid, "table", name, "sql", 1, 10)
+            nodes[name] = nid
+        db.insert_edge(nodes["stg_orders"], nodes["raw_orders"], "references")
+        db.insert_edge(nodes["stg_payments"], nodes["raw_payments"], "references")
+
+        engine = ConventionEngine(db, repo_id)
+        engine.run_inference()
+    finally:
+        db.close()
+    return db_path
+
+
 def test_cli_conventions_init(tmp_path):
-    """conventions --init generates YAML with confidence comments."""
+    """conventions --init generates valid YAML with confidence comments."""
     db = GraphDB()
     try:
         repo_id, nodes = _setup_layered_repo_with_edges(db)
@@ -1304,44 +1334,59 @@ def test_cli_conventions_init_no_overwrite(tmp_path):
 
     from sqlprism.cli import cli
 
-    # Create a dummy conventions file
-    conventions_file = tmp_path / "sqlprism.conventions.yml"
-    conventions_file.write_text("# existing\n")
+    db_path = _create_test_db(tmp_path)
 
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # Write the file in the isolated dir
         Path("sqlprism.conventions.yml").write_text("# existing\n")
-        result = runner.invoke(cli, ["conventions", "init"])
-        # Should fail because file exists and no --force
-        assert result.exit_code != 0 or "already exists" in result.output
+        result = runner.invoke(
+            cli, ["conventions", "init", "--db", str(db_path)]
+        )
+        assert result.exit_code == 1
+        assert "already exists" in result.output
 
 
-def test_cli_conventions_refresh():
-    """conventions --refresh updates tables without YAML."""
-    db = GraphDB()
-    try:
-        repo_id, nodes = _setup_layered_repo_with_edges(db)
-        db.insert_edge(nodes["stg_orders"], nodes["raw_orders"], "references")
+def test_cli_conventions_init_with_force(tmp_path):
+    """conventions --init --force overwrites existing file."""
+    from click.testing import CliRunner
 
-        engine = ConventionEngine(db, repo_id)
-        result = engine.run_inference()
+    from sqlprism.cli import cli
 
-        assert result["layers_detected"] >= 2
-        assert result["conventions_stored"] > 0
+    db_path = _create_test_db(tmp_path)
 
-        # Verify conventions in DB
-        count = db.conn.execute(
-            "SELECT COUNT(*) FROM conventions WHERE repo_id = ?",
-            [repo_id],
-        ).fetchone()[0]
-        assert count > 0
-    finally:
-        db.close()
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("sqlprism.conventions.yml").write_text("# old\n")
+        result = runner.invoke(
+            cli, ["conventions", "init", "--db", str(db_path), "--force"]
+        )
+        assert result.exit_code == 0
+        assert "Wrote" in result.output
+        content = Path("sqlprism.conventions.yml").read_text()
+        assert "conventions:" in content
+        assert "confidence:" in content
+
+
+def test_cli_conventions_refresh(tmp_path):
+    """conventions --refresh updates tables and prints stats."""
+    from click.testing import CliRunner
+
+    from sqlprism.cli import cli
+
+    db_path = _create_test_db(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["conventions", "refresh", "--db", str(db_path)]
+    )
+    assert result.exit_code == 0
+    assert "layers" in result.output
+    assert "conventions stored" in result.output
+    assert "Done." in result.output
 
 
 def test_cli_conventions_diff(tmp_path):
-    """conventions --diff shows changes since init."""
+    """conventions --diff reports no changes after fresh init."""
     db = GraphDB()
     try:
         repo_id, nodes = _setup_layered_repo_with_edges(db)
@@ -1350,26 +1395,57 @@ def test_cli_conventions_diff(tmp_path):
         engine = ConventionEngine(db, repo_id)
         engine.run_inference()
 
-        # Write initial YAML
+        # Write YAML and immediately diff — should be "No changes"
         yaml_content = engine.generate_yaml()
         yaml_path = tmp_path / "sqlprism.conventions.yml"
         yaml_path.write_text(yaml_content)
 
-        # Get diff — should show no changes (or just confidence info)
         diff = engine.get_diff(yaml_path)
-        assert isinstance(diff, str)
+        assert diff == "No changes detected."
     finally:
         db.close()
 
 
-def test_cli_conventions_init_empty():
-    """conventions --init on empty database shows helpful message."""
+def test_cli_conventions_diff_detects_changes(tmp_path):
+    """conventions --diff detects when naming pattern changes."""
     db = GraphDB()
     try:
-        repo_id = db.upsert_repo("empty", "/tmp/empty")
-        engine = ConventionEngine(db, repo_id)
+        repo_id, nodes = _setup_layered_repo_with_edges(db)
+        db.insert_edge(nodes["stg_orders"], nodes["raw_orders"], "references")
 
-        yaml_content = engine.generate_yaml()
-        assert "No conventions found" in yaml_content
+        engine = ConventionEngine(db, repo_id)
+        engine.run_inference()
+
+        # Write YAML with a different naming pattern
+        yaml_path = tmp_path / "sqlprism.conventions.yml"
+        yaml_path.write_text(
+            'conventions:\n  staging:\n    naming: "old_pattern"\n'
+        )
+
+        diff = engine.get_diff(yaml_path)
+        assert "staging.naming" in diff
+        assert "old_pattern" in diff
     finally:
         db.close()
+
+
+def test_cli_conventions_init_empty(tmp_path):
+    """conventions --init on empty database shows helpful message."""
+    from click.testing import CliRunner
+
+    from sqlprism.cli import cli
+
+    # Create DB with a repo but no models
+    db_path = tmp_path / "empty.duckdb"
+    db = GraphDB(str(db_path))
+    db.upsert_repo("empty", str(tmp_path))
+    db.close()
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(
+            cli, ["conventions", "init", "--db", str(db_path)]
+        )
+        assert result.exit_code == 0
+        content = Path("sqlprism.conventions.yml").read_text()
+        assert "No conventions found" in content


### PR DESCRIPTION
Closes #67

## Summary
- `sqlprism conventions init`: runs inference, writes `sqlprism.conventions.yml` with confidence scores as comments (`--force` to overwrite)
- `sqlprism conventions refresh`: re-runs inference, updates DB tables only
- `sqlprism conventions diff`: compares current DB conventions against YAML file
- `ConventionEngine.generate_yaml()`: formats conventions as human-readable YAML
- `ConventionEngine.get_diff(yaml_path)`: compares DB state against YAML

## Test Plan

| Scenario | Test | Status |
|----------|------|--------|
| Init generates YAML | `test_cli_conventions_init` | :white_check_mark: |
| Init does not overwrite | `test_cli_conventions_init_no_overwrite` | :white_check_mark: |
| Refresh updates tables | `test_cli_conventions_refresh` | :white_check_mark: |
| Diff shows changes | `test_cli_conventions_diff` | :white_check_mark: |
| Init on empty database | `test_cli_conventions_init_empty` | :white_check_mark: |