### PR TITLE
feat-69-search-by-tag-list-tags

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -3274,7 +3274,7 @@ class GraphDB:
 
         models = [
             {
-                "name": r[2],
+                "node_name": r[2],
                 "node_id": r[1],
                 "confidence": r[3],
                 "source": r[4],
@@ -3303,7 +3303,7 @@ class GraphDB:
 
         sql = (
             "SELECT tag_name, COUNT(*) AS model_count, "
-            "AVG(confidence) AS avg_confidence "
+            "ROUND(AVG(confidence), 4) AS avg_confidence "
             "FROM semantic_tags"
         )
         params: list = []

--- a/src/sqlprism/core/mcp_tools.py
+++ b/src/sqlprism/core/mcp_tools.py
@@ -866,6 +866,8 @@ class SearchByTagInput(BaseModel):
     )
     min_confidence: float | None = Field(
         None,
+        ge=0.0,
+        le=1.0,
         description="Minimum confidence threshold (0.0-1.0). Only return models above this confidence.",
     )
     repo: str | None = Field(

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -2077,10 +2077,13 @@ def test_search_by_tag_ranked():
         assert len(result["models"]) == 4
 
         confidences = [m["confidence"] for m in result["models"]]
-        assert confidences == sorted(confidences, reverse=True)
+        expected = [0.90, 0.85, 0.70, 0.65]
+        assert len(confidences) == len(expected)
+        for actual, exp in zip(confidences, expected):
+            assert abs(actual - exp) < 0.01, f"Expected ~{exp}, got {actual}"
 
         for m in result["models"]:
-            assert "name" in m
+            assert "node_name" in m
             assert "confidence" in m
             assert "source" in m
     finally:
@@ -2110,6 +2113,7 @@ def test_search_by_tag_min_confidence():
         assert result["total"] == 3
         assert len(result["models"]) == 3
         assert all(m["confidence"] >= 0.5 for m in result["models"])
+        assert not any(m["node_name"] == "customer_health" for m in result["models"])
     finally:
         db.close()
 
@@ -2168,8 +2172,8 @@ def test_list_tags_all():
         assert tag_map["customer"]["model_count"] == 4
         assert tag_map["order"]["model_count"] == 3
 
-        assert "avg_confidence" in tag_map["customer"]
-        assert "avg_confidence" in tag_map["order"]
+        assert abs(tag_map["customer"]["avg_confidence"] - 0.775) < 0.01
+        assert abs(tag_map["order"]["avg_confidence"] - 0.80) < 0.01
     finally:
         db.close()
 
@@ -2224,10 +2228,32 @@ def test_tags_repo_filter():
         # search_by_tag filtered to project_a
         result_search = db.query_search_by_tag(tag="customer", repo="project_a")
         assert result_search["total"] == 2
-        assert all(m["name"].startswith("customer_") for m in result_search["models"])
+        assert all(m["node_name"].startswith("customer_") for m in result_search["models"])
 
         # search_by_tag for tag that only exists in project_b, filtered to project_a
         result_empty = db.query_search_by_tag(tag="order", repo="project_a")
         assert result_empty["total"] == 0
+    finally:
+        db.close()
+
+
+def test_search_by_tag_repo_not_found():
+    """query_search_by_tag returns error when repo name doesn't exist."""
+    db = GraphDB()
+    try:
+        result = db.query_search_by_tag(tag="customer", repo="nonexistent")
+        assert "error" in result
+        assert "nonexistent" in result["error"]
+    finally:
+        db.close()
+
+
+def test_list_tags_repo_not_found():
+    """query_list_tags returns error when repo name doesn't exist."""
+    db = GraphDB()
+    try:
+        result = db.query_list_tags(repo="nonexistent")
+        assert "error" in result
+        assert "nonexistent" in result["error"]
     finally:
         db.close()


### PR DESCRIPTION
Closes #69

## Summary
- Add `search_by_tag` MCP tool — finds models tagged with a business domain concept, ranked by confidence
- Add `list_tags` MCP tool — returns all semantic tags with model counts and avg confidence
- Both tools support optional repo filter and are read-only/idempotent
- `search_by_tag` supports `min_confidence` filter

## Test Plan

| Scenario | Test | Status |
|----------|------|--------|
| search_by_tag ranked results | `test_search_by_tag_ranked` | pass |
| search_by_tag min_confidence | `test_search_by_tag_min_confidence` | pass |
| search_by_tag unknown tag | `test_search_by_tag_unknown` | pass |
| list_tags all tags | `test_list_tags_all` | pass |
| list_tags empty | `test_list_tags_empty` | pass |
| Repo filter | `test_tags_repo_filter` | pass |