### PR TITLE
fix(graph): trace from all matching nodes, not just the first (#107)

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -2687,7 +2687,7 @@ class GraphDB:
         if not start_nodes:
             return {"root": None, "paths": [], "depth_summary": {}, "repos_affected": []}
 
-        start_id = start_nodes[0][0]
+        start_ids = [r[0] for r in start_nodes]
 
         # "both" — run downstream and upstream separately and merge
         if direction == "both":
@@ -2722,16 +2722,24 @@ class GraphDB:
                 "repos_affected": list(set(down["repos_affected"] + up["repos_affected"])),
             }
 
-        # Dispatch to PGQ or CTE
+        # Dispatch to PGQ or CTE — trace from ALL matching start nodes
+        all_paths: list[dict] = []
+        seen_names: set[str] = set()
         use_pgq = self.has_pgq and exclude_edges is None
-        if use_pgq:
-            paths = self._trace_pgq(
-                start_id, name, direction, max_depth, limit, include_snippets
-            )
-        else:
-            paths = self._trace_cte(
-                start_id, direction, max_depth, limit, include_snippets, exclude_edges
-            )
+        for sid in start_ids:
+            if use_pgq:
+                paths = self._trace_pgq(
+                    sid, name, direction, max_depth, limit, include_snippets
+                )
+            else:
+                paths = self._trace_cte(
+                    sid, direction, max_depth, limit, include_snippets, exclude_edges
+                )
+            for p in paths:
+                if p["name"] not in seen_names:
+                    seen_names.add(p["name"])
+                    all_paths.append(p)
+        paths = all_paths[:limit]
 
         depth_summary: dict[int, int] = {}
         repos_affected: set[str] = set()


### PR DESCRIPTION
## Summary

- `query_trace` now starts from ALL nodes matching the name, not just the first
- When a name has multiple nodes (table/view/query), edges from all are followed
- Results are deduplicated by name across all start nodes

Previously `clients_daily_v6` (3 nodes: table, view, query) would only trace from the table node which had no outbound edges, returning empty results.

## Test Plan

- [x] All 16 trace tests pass
- [x] `query trace clients_daily_v6 --direction downstream` now returns 2 paths
- [x] `query trace clients_daily_v6 --direction upstream` now returns 3 paths
- [x] Lint clean

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)