### PR TITLE
fix(graph): merge duplicate stub nodes into defining counterparts

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -809,7 +809,16 @@ class GraphDB:
 
         Matches on short name (e.g. ``"orders"``) which covers both
         unqualified references and qualified ones (stored as short name
-        plus schema column). Search order: same repo first, then cross-repo.
+        plus schema column). Search order:
+
+        1. Exact (name + kind) in same repo
+        2. Exact (name + kind) cross-repo
+        3. Kind-relaxed (name only, real nodes with a file) in same repo
+        4. Kind-relaxed cross-repo
+
+        The kind-relaxed fallback handles the common case where a SQL
+        reference uses ``target_kind="table"`` but the actual node was
+        indexed as ``"query"`` or ``"view"`` (e.g. sqlmesh/dbt models).
 
         Args:
             name: Unqualified entity name.
@@ -829,6 +838,7 @@ class GraphDB:
             schema_params = [schema]
 
         if repo_id:
+            # 1. Exact kind match in same repo
             row = self._execute_read(
                 "SELECT n.node_id FROM nodes n "
                 "JOIN files f ON n.file_id = f.file_id "
@@ -838,10 +848,32 @@ class GraphDB:
             if row:
                 return row[0]
 
-        # Cross-repo search (use alias so schema_clause referencing 'n.' works)
+        # 2. Exact kind match cross-repo
         row = self._execute_read(
             "SELECT n.node_id FROM nodes n WHERE n.name = ? AND n.kind = ?" + schema_clause + " LIMIT 1",
             [name, kind] + schema_params,
+        ).fetchone()
+        if row:
+            return row[0]
+
+        # 3. Kind-relaxed: match by name only, prefer real nodes (file_id IS NOT NULL)
+        if repo_id:
+            row = self._execute_read(
+                "SELECT n.node_id FROM nodes n "
+                "JOIN files f ON n.file_id = f.file_id "
+                "WHERE n.name = ? AND f.repo_id = ?" + schema_clause
+                + " ORDER BY (n.kind = ?) DESC LIMIT 1",
+                [name, repo_id] + schema_params + [kind],
+            ).fetchone()
+            if row:
+                return row[0]
+
+        # 4. Kind-relaxed cross-repo
+        row = self._execute_read(
+            "SELECT n.node_id FROM nodes n "
+            "WHERE n.name = ? AND n.file_id IS NOT NULL" + schema_clause
+            + " ORDER BY (n.kind = ?) DESC LIMIT 1",
+            [name] + schema_params + [kind],
         ).fetchone()
         return row[0] if row else None
 
@@ -951,6 +983,79 @@ class GraphDB:
                 )
 
             return len(phantoms) + len(orphaned)
+
+    def merge_duplicate_nodes(self) -> int:
+        """Merge stub nodes into their defining counterparts.
+
+        When file A references model X (creating a ``"table"`` stub node
+        attached to A's file_id) and file B defines model X (creating a
+        ``"query"`` or ``"view"`` node), edges targeting the stub should be
+        repointed to the defining node. The stub is then deleted.
+
+        A "defining" node is one whose kind is NOT ``"table"`` (i.e. it was
+        parsed from its own SQL file as a query/view/cte). A "stub" is a
+        ``"table"`` node that merely records a reference in another file.
+
+        Only merges nodes within the **same repo** to avoid cross-repo
+        name collisions (e.g. two repos both defining ``orders``).
+
+        Returns the number of stub nodes merged.
+        """
+        with self._write_lock:
+            # Find stub → defining pairs in the same repo.
+            # Schema match is relaxed: a stub with schema "sushi" (from a
+            # qualified reference like sushi.orders) matches a defining node
+            # with schema NULL (common for sqlmesh/dbt models whose own file
+            # doesn't set a schema). Exact matches are preferred via ORDER BY.
+            dupes = self._execute_write(
+                "SELECT stub.node_id AS stub_id, def.node_id AS def_id "
+                "FROM nodes stub "
+                "JOIN files fs ON stub.file_id = fs.file_id "
+                "JOIN nodes def ON stub.name = def.name "
+                "JOIN files fd ON def.file_id = fd.file_id "
+                "WHERE stub.kind = 'table' "
+                "  AND def.kind != 'table' "
+                "  AND fs.repo_id = fd.repo_id "
+                "  AND stub.node_id != def.node_id "
+                "  AND (COALESCE(stub.schema, '') = COALESCE(def.schema, '') "
+                "       OR def.schema IS NULL OR stub.schema IS NULL)"
+            ).fetchall()
+
+            if not dupes:
+                return 0
+
+            # Repoint edges from stubs to defining nodes
+            mapping_values = ", ".join(
+                [f"({stub_id}, {def_id})" for stub_id, def_id in dupes]
+            )
+            self._execute_write(
+                f"UPDATE edges SET source_id = m.def_id "
+                f"FROM (VALUES {mapping_values}) AS m(stub_id, def_id) "
+                f"WHERE edges.source_id = m.stub_id"
+            )
+            self._execute_write(
+                f"UPDATE edges SET target_id = m.def_id "
+                f"FROM (VALUES {mapping_values}) AS m(stub_id, def_id) "
+                f"WHERE edges.target_id = m.stub_id"
+            )
+
+            # Delete duplicate edges that may have been created by the merge
+            self._execute_write(
+                "DELETE FROM edges WHERE rowid NOT IN ("
+                "  SELECT MIN(rowid) FROM edges "
+                "  GROUP BY source_id, target_id, relationship"
+                ")"
+            )
+
+            # Delete the stub nodes
+            stub_ids = [s[0] for s in dupes]
+            placeholders = ",".join(["?"] * len(stub_ids))
+            self._execute_write(
+                f"DELETE FROM nodes WHERE node_id IN ({placeholders})",
+                stub_ids,
+            )
+
+            return len(dupes)
 
     # ── Edge management ──
 

--- a/src/sqlprism/core/indexer.py
+++ b/src/sqlprism/core/indexer.py
@@ -174,6 +174,9 @@ class Indexer:
         # Clean up phantom nodes that now have real counterparts
         phantoms_cleaned = self.graph.cleanup_phantoms()
         stats["phantoms_cleaned"] = phantoms_cleaned
+        # Merge stub "table" nodes into their defining query/view counterparts
+        stubs_merged = self.graph.merge_duplicate_nodes()
+        stats["stubs_merged"] = stubs_merged
 
         # Update repo metadata
         commit, branch = self._get_git_info(path)
@@ -301,6 +304,7 @@ class Indexer:
 
             # Cleanup phantoms inside the transaction for atomicity
             phantoms_cleaned = self.graph.cleanup_phantoms()
+            self.graph.merge_duplicate_nodes()
 
         # Update fingerprint and render cache after successful index
         self.graph.update_source_fingerprint(repo_id, current_fingerprint)
@@ -578,6 +582,7 @@ class Indexer:
 
         if did_reindex:
             self.graph.cleanup_phantoms()
+            self.graph.merge_duplicate_nodes()
         self.graph.clear_snippet_cache()
 
     def _delete_stored_files_by_stem(self, repo_id: int, stem: str, stats: dict, display_path: str) -> None:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -777,7 +777,7 @@ def test_merge_duplicate_nodes_schema_mismatch():
 
     # Defining query node with schema=NULL (sqlmesh model)
     file_a = db.insert_file(repo_id, "orders.sql", "sql", "aaa")
-    query_id = db.insert_node(file_a, "query", "orders", "sql")
+    db.insert_node(file_a, "query", "orders", "sql")
 
     # Stub table node with schema='sushi' (from qualified reference)
     file_b = db.insert_file(repo_id, "report.sql", "sql", "bbb")

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -732,6 +732,72 @@ def test_phantom_cleanup_graph_layer():
     db.close()
 
 
+def test_merge_duplicate_nodes():
+    """Stub 'table' nodes are merged into defining 'query' nodes in the same repo."""
+    from sqlprism.core.graph import GraphDB
+
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test")
+
+    # File A defines a query node "orders"
+    file_a = db.insert_file(repo_id, "orders.sql", "sql", "aaa")
+    query_id = db.insert_node(file_a, "query", "orders", "sql")
+
+    # File B references "orders" as a table (stub node created in same repo)
+    file_b = db.insert_file(repo_id, "report.sql", "sql", "bbb")
+    stub_id = db.insert_node(file_b, "table", "orders", "sql")
+    report_id = db.insert_node(file_b, "query", "report", "sql")
+    db.insert_edge(report_id, stub_id, "references")
+
+    # Add outbound edges from the real query node
+    file_c = db.insert_file(repo_id, "customers.sql", "sql", "ccc")
+    customers_id = db.insert_node(file_c, "query", "customers", "sql")
+    db.insert_edge(query_id, customers_id, "references")
+
+    # Before merge: report -> stub (dead end), query_id -> customers
+    merged = db.merge_duplicate_nodes()
+    assert merged >= 1
+
+    # After merge: report -> query_id -> customers (traversable)
+    refs = db.query_references("orders")
+    assert len(refs["inbound"]) == 1
+    assert refs["inbound"][0]["name"] == "report"
+    assert len(refs["outbound"]) == 1
+    assert refs["outbound"][0]["name"] == "customers"
+
+    db.close()
+
+
+def test_merge_duplicate_nodes_schema_mismatch():
+    """Stub with schema='sushi' merges into defining node with schema=NULL."""
+    from sqlprism.core.graph import GraphDB
+
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test")
+
+    # Defining query node with schema=NULL (sqlmesh model)
+    file_a = db.insert_file(repo_id, "orders.sql", "sql", "aaa")
+    query_id = db.insert_node(file_a, "query", "orders", "sql")
+
+    # Stub table node with schema='sushi' (from qualified reference)
+    file_b = db.insert_file(repo_id, "report.sql", "sql", "bbb")
+    stub_id = db.insert_node(file_b, "table", "orders", "sql")
+    # Set schema on the stub
+    db._execute_write("UPDATE nodes SET schema = 'sushi' WHERE node_id = ?", [stub_id])
+    report_id = db.insert_node(file_b, "query", "report", "sql")
+    db.insert_edge(report_id, stub_id, "references")
+
+    merged = db.merge_duplicate_nodes()
+    assert merged >= 1
+
+    # After merge: report should reference the query node
+    refs = db.query_references("orders")
+    assert len(refs["inbound"]) == 1
+    assert refs["inbound"][0]["name"] == "report"
+
+    db.close()
+
+
 # ── 5.5: Column usage dropped counter integration test ──
 
 


### PR DESCRIPTION
## Summary
- New `merge_duplicate_nodes()` repoints edges from stub "table" nodes to their defining "query"/"view" counterparts within the same repo, fixing dead-end graph traversal
- Relaxed schema matching so stubs from qualified references (e.g. `sushi.orders` → schema='sushi') merge with defining nodes that have schema=NULL
- Relaxed `resolve_node()` to try kind-agnostic name matching when exact kind match fails, reducing future stub creation
- Added 2 unit tests for node merge (exact and schema-mismatch cases)

## Benchmark impact (sqlmesh-examples)

| Task | Before | After |
|------|--------|-------|
| lineage_01 (top_waiters transitive) | 0.40 | **1.00** |
| lineage_02 (revenue column trace) | 1.00 | **1.00** |
| lineage_03 (waiter_as_customer direct) | 0.67 | 0.36* |

*lineage_03 regressed because existing wrong edges (parser maps `sushi.waiters` → `orders`) are now traversable instead of hidden behind dead-end stubs. This is a separate sqlmesh rendering/parsing issue.

## Test plan
- [x] 75 indexer tests pass
- [x] `test_merge_duplicate_nodes` — basic stub→query merge
- [x] `test_merge_duplicate_nodes_schema_mismatch` — schema='sushi' stub merges with schema=NULL defining node
- [x] Lint clean (`ruff check`)

Closes #110