### PR TITLE
fix(graph): inline DuckPGQ params and filter noise nodes

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -2545,7 +2545,8 @@ class GraphDB:
                     snippet = self._read_snippet(r[5], r[4], r[6], r[7])
                     if snippet:
                         entry["snippet"] = snippet
-                result["inbound"].append(entry)
+                if not self._is_noise_node(entry):
+                    result["inbound"].append(entry)
 
         if direction in ("both", "outbound"):
             outbound_sql = (
@@ -2572,7 +2573,8 @@ class GraphDB:
                     snippet = self._read_snippet(r[5], r[4], r[6], r[7])
                     if snippet:
                         entry["snippet"] = snippet
-                result["outbound"].append(entry)
+                if not self._is_noise_node(entry):
+                    result["outbound"].append(entry)
 
         return result
 
@@ -2841,7 +2843,7 @@ class GraphDB:
                     sid, direction, max_depth, limit, include_snippets, exclude_edges
                 )
             for p in paths:
-                if p["name"] not in seen_names:
+                if p["name"] not in seen_names and not self._is_noise_node(p):
                     seen_names.add(p["name"])
                     all_paths.append(p)
         paths = all_paths[:limit]
@@ -2859,6 +2861,24 @@ class GraphDB:
             "depth_summary": depth_summary,
             "repos_affected": sorted(repos_affected),
         }
+
+    @staticmethod
+    def _is_noise_node(path_entry: dict) -> bool:
+        """Return True for nodes that should be excluded from trace results.
+
+        Filters out:
+        - dbt test nodes (not_null_*, unique_*, relationships_*, accepted_values_*)
+        - CTE-kind nodes (internal to a query, not standalone models)
+        """
+        name = path_entry.get("name", "")
+        kind = path_entry.get("kind", "")
+        if kind == "cte":
+            return True
+        # dbt schema test patterns
+        for prefix in ("not_null_", "unique_", "relationships_", "accepted_values_"):
+            if name.startswith(prefix):
+                return True
+        return False
 
     def _trace_cte(
         self,
@@ -2971,22 +2991,24 @@ class GraphDB:
         # -> follows source-to-target. <- follows target-to-source.
         # Downstream (what does start_id reach) = follow -> (outgoing).
         # Upstream (what reaches start_id) = follow <- (incoming).
+        # DuckPGQ does not support bind parameters inside GRAPH_TABLE
+        # MATCH patterns, so we inline start_id (always an int) directly.
         if direction == "downstream":
-            edge_pattern = f"(a:nodes WHERE a.node_id = ?)-[e:edges]->{{1,{max_depth}}}"
+            edge_pattern = f"(a:nodes WHERE a.node_id = {int(start_id)})-[e:edges]->{{1,{max_depth}}}"
         else:
-            edge_pattern = f"(a:nodes WHERE a.node_id = ?)<-[e:edges]-{{1,{max_depth}}}"
+            edge_pattern = f"(a:nodes WHERE a.node_id = {int(start_id)})<-[e:edges]-{{1,{max_depth}}}"
 
         # Step 1: PGQ bounded traversal to discover reachable node_ids
         pgq_sql = (
             f"SELECT DISTINCT node_id FROM ("
             f"FROM GRAPH_TABLE (sqlprism_graph "
             f"MATCH {edge_pattern}(b:nodes) "
-            f"COLUMNS (b.node_id))) LIMIT ?"
+            f"COLUMNS (b.node_id))) LIMIT {int(limit)}"
         )
         try:
             node_ids = [
                 r[0]
-                for r in self._execute_read(pgq_sql, [start_id, limit]).fetchall()
+                for r in self._execute_read(pgq_sql, []).fetchall()
             ]
         except duckdb.Error as e:
             logger.warning("DuckPGQ trace failed for %s: %s, falling back to CTE", name, e)

--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -2829,19 +2829,13 @@ class GraphDB:
                 "repos_affected": list(set(down["repos_affected"] + up["repos_affected"])),
             }
 
-        # Dispatch to PGQ or CTE — trace from ALL matching start nodes
+        # Trace from ALL matching start nodes via recursive CTE.
         all_paths: list[dict] = []
         seen_names: set[str] = set()
-        use_pgq = self.has_pgq and exclude_edges is None
         for sid in start_ids:
-            if use_pgq:
-                paths = self._trace_pgq(
-                    sid, name, direction, max_depth, limit, include_snippets
-                )
-            else:
-                paths = self._trace_cte(
-                    sid, direction, max_depth, limit, include_snippets, exclude_edges
-                )
+            paths = self._trace_cte(
+                sid, direction, max_depth, limit, include_snippets, exclude_edges
+            )
             for p in paths:
                 if p["name"] not in seen_names and not self._is_noise_node(p):
                     seen_names.add(p["name"])
@@ -2965,127 +2959,6 @@ class GraphDB:
             }
             if include_snippets:
                 snippet = self._read_snippet(r[8], r[7], r[9], r[10])
-                if snippet:
-                    entry["snippet"] = snippet
-            paths.append(entry)
-
-        return paths
-
-    def _trace_pgq(
-        self,
-        start_id: int,
-        name: str,
-        direction: str,
-        max_depth: int,
-        limit: int,
-        include_snippets: bool,
-    ) -> list[dict]:
-        """Trace dependencies using DuckPGQ GRAPH_TABLE bounded traversal.
-
-        Note: PGQ bounded traversal does not provide per-hop depth or
-        per-hop edge attributes. Depth is recovered via a lightweight
-        CTE after node discovery. Relationship defaults to the edge's
-        actual value when a direct edge exists.
-        """
-        # Edge direction: source_id -> target_id in our model.
-        # -> follows source-to-target. <- follows target-to-source.
-        # Downstream (what does start_id reach) = follow -> (outgoing).
-        # Upstream (what reaches start_id) = follow <- (incoming).
-        # DuckPGQ does not support bind parameters inside GRAPH_TABLE
-        # MATCH patterns, so we inline start_id (always an int) directly.
-        if direction == "downstream":
-            edge_pattern = f"(a:nodes WHERE a.node_id = {int(start_id)})-[e:edges]->{{1,{max_depth}}}"
-        else:
-            edge_pattern = f"(a:nodes WHERE a.node_id = {int(start_id)})<-[e:edges]-{{1,{max_depth}}}"
-
-        # Step 1: PGQ bounded traversal to discover reachable node_ids
-        pgq_sql = (
-            f"SELECT DISTINCT node_id FROM ("
-            f"FROM GRAPH_TABLE (sqlprism_graph "
-            f"MATCH {edge_pattern}(b:nodes) "
-            f"COLUMNS (b.node_id))) LIMIT {int(limit)}"
-        )
-        try:
-            node_ids = [
-                r[0]
-                for r in self._execute_read(pgq_sql, []).fetchall()
-            ]
-        except duckdb.Error as e:
-            logger.warning("DuckPGQ trace failed for %s: %s, falling back to CTE", name, e)
-            return self._trace_cte(
-                start_id, direction, max_depth, limit, include_snippets
-            )
-
-        if not node_ids:
-            return []
-
-        # Step 2: Recover depth via lightweight CTE on discovered nodes only
-        if direction == "downstream":
-            source_col, target_col = "source_id", "target_id"
-        else:
-            source_col, target_col = "target_id", "source_id"
-
-        placeholders = ",".join("?" for _ in node_ids)
-        depth_sql = f"""
-        WITH RECURSIVE depth_trace AS (
-            SELECT e.{target_col} as node_id, 1 as depth
-            FROM edges e
-            WHERE e.{source_col} = ?
-            AND e.{target_col} IN ({placeholders})
-
-            UNION ALL
-
-            SELECT e.{target_col}, dt.depth + 1
-            FROM edges e
-            JOIN depth_trace dt ON e.{source_col} = dt.node_id
-            WHERE dt.depth < ?
-            AND e.{target_col} IN ({placeholders})
-        )
-        SELECT node_id, MIN(depth) as min_depth FROM depth_trace GROUP BY node_id
-        """
-        depth_params = [start_id] + node_ids + [max_depth] + node_ids
-        depth_rows = self._execute_read(depth_sql, depth_params).fetchall()
-        depth_map: dict[int, int] = {r[0]: r[1] for r in depth_rows}
-
-        # Step 3: Enrich with metadata (file, repo, edge relationship)
-        # Include start_id in edge source lookup so depth-1 nodes get real relationship
-        source_ids = [start_id] + node_ids
-        source_ph = ",".join("?" for _ in source_ids)
-        enrich_sql = (
-            f"SELECT n.node_id, n.name, n.kind, n.language, "
-            f"n.line_start, n.line_end, f.path, r.name, "
-            f"e.relationship, e.context "
-            f"FROM nodes n "
-            f"LEFT JOIN files f ON n.file_id = f.file_id "
-            f"LEFT JOIN repos r ON f.repo_id = r.repo_id "
-            f"LEFT JOIN edges e ON e.{target_col} = n.node_id "
-            f"AND e.{source_col} IN ({source_ph}) "
-            f"WHERE n.node_id IN ({placeholders}) "
-            f"AND n.file_id IS NOT NULL "
-            f"ORDER BY n.name"
-        )
-        enrich_params = source_ids + node_ids
-        rows = self._execute_read(enrich_sql, enrich_params).fetchall()
-
-        seen: set[int] = set()
-        paths: list[dict] = []
-        for r in rows:
-            nid, node_name, node_kind, language, line_start, line_end, fp, rn, rel, ctx = r
-            if nid in seen:
-                continue
-            seen.add(nid)
-            entry: dict = {
-                "name": node_name,
-                "kind": node_kind,
-                "language": language,
-                "relationship": rel or "references",
-                "context": ctx,
-                "depth": depth_map.get(nid, 1),
-                "file": fp,
-                "repo": rn,
-            }
-            if include_snippets:
-                snippet = self._read_snippet(rn, fp, line_start, line_end)
                 if snippet:
                     entry["snippet"] = snippet
             paths.append(entry)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1523,36 +1523,3 @@ def test_trace_max_depth_boundary():
     db.close()
 
 
-def test_trace_pgq_cte_parity():
-    """PGQ and CTE produce the same set of node names and depths."""
-    import pytest
-
-    db = _build_trace_graph()
-    db.refresh_property_graph()
-
-    if not db.has_pgq:
-        db.close()
-        pytest.skip("DuckPGQ not available in this environment")
-
-    start_id = db._execute_read(
-        "SELECT node_id FROM nodes WHERE name = ?", ["raw_orders"]
-    ).fetchone()[0]
-
-    pgq_paths = db._trace_pgq(
-        start_id, "raw_orders", "downstream", 3, 100, False
-    )
-    cte_paths = db._trace_cte(start_id, "downstream", 3, 100, False)
-
-    pgq_names = {p["name"] for p in pgq_paths}
-    cte_names = {p["name"] for p in cte_paths}
-
-    # Both engines must find exactly the same nodes
-    assert pgq_names == cte_names
-    assert pgq_names == {"stg_orders", "marts_revenue", "dim_customers"}
-
-    # Depths should also match now that PGQ recovers depth via CTE
-    pgq_depths = {p["name"]: p["depth"] for p in pgq_paths}
-    cte_depths = {p["name"]: p["depth"] for p in cte_paths}
-    assert pgq_depths == cte_depths
-
-    db.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -732,6 +732,70 @@ def test_phantom_cleanup_graph_layer():
     db.close()
 
 
+def test_noise_nodes_filtered_from_trace():
+    """dbt test nodes and CTEs are excluded from trace results."""
+    from sqlprism.core.graph import GraphDB
+
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test")
+
+    file_a = db.insert_file(repo_id, "stg_orders.sql", "sql", "aaa")
+    stg_id = db.insert_node(file_a, "query", "stg_orders", "sql")
+
+    # Real downstream model
+    file_b = db.insert_file(repo_id, "orders.sql", "sql", "bbb")
+    orders_id = db.insert_node(file_b, "query", "orders", "sql")
+    db.insert_edge(stg_id, orders_id, "references")
+
+    # dbt test node (should be filtered)
+    file_c = db.insert_file(repo_id, "test_not_null.sql", "sql", "ccc")
+    test_id = db.insert_node(file_c, "table", "not_null_stg_orders_order_id", "sql")
+    db.insert_edge(stg_id, test_id, "references")
+
+    # CTE node (should be filtered)
+    cte_id = db.insert_node(file_b, "cte", "joined", "sql")
+    db.insert_edge(stg_id, cte_id, "references")
+
+    db.refresh_property_graph()
+    result = db.query_trace("stg_orders", direction="downstream", max_depth=3)
+    names = [p["name"] for p in result["paths"]]
+
+    assert "orders" in names
+    assert "not_null_stg_orders_order_id" not in names
+    assert "joined" not in names
+
+    db.close()
+
+
+def test_noise_nodes_filtered_from_references():
+    """dbt test nodes are excluded from query_references results."""
+    from sqlprism.core.graph import GraphDB
+
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test")
+
+    file_a = db.insert_file(repo_id, "stg_orders.sql", "sql", "aaa")
+    stg_id = db.insert_node(file_a, "query", "stg_orders", "sql")
+
+    # Real inbound ref
+    file_b = db.insert_file(repo_id, "orders.sql", "sql", "bbb")
+    orders_id = db.insert_node(file_b, "query", "orders", "sql")
+    db.insert_edge(orders_id, stg_id, "references")
+
+    # dbt test inbound ref (should be filtered)
+    file_c = db.insert_file(repo_id, "test.sql", "sql", "ccc")
+    test_id = db.insert_node(file_c, "table", "unique_stg_orders_order_id", "sql")
+    db.insert_edge(test_id, stg_id, "references")
+
+    refs = db.query_references("stg_orders")
+    inbound_names = [r["name"] for r in refs["inbound"]]
+
+    assert "orders" in inbound_names
+    assert "unique_stg_orders_order_id" not in inbound_names
+
+    db.close()
+
+
 def test_merge_duplicate_nodes():
     """Stub 'table' nodes are merged into defining 'query' nodes in the same repo."""
     from sqlprism.core.graph import GraphDB


### PR DESCRIPTION
## Summary

Removes the DuckPGQ path from `_trace_pgq` and routes `query_trace` unconditionally to the recursive-CTE path. Keeps the noise-node filter (`_is_noise_node`) that excludes dbt test nodes (`not_null_*`, `unique_*`, `relationships_*`, `accepted_values_*`) and CTE-kind nodes from `trace_dependencies` and `query_references` results.

## Why the original PGQ approach was abandoned

The initial version of this PR inlined `start_id` and `limit` into `GRAPH_TABLE MATCH` patterns to stop every trace from falling back to CTE. That change made CI crash:

```
Fatal Python error: Aborted
  graph.py:_execute_read
  graph.py:_trace_pgq
  graph.py:query_trace
```

Root cause (verified in isolation against DuckDB 1.5.0 + DuckPGQ `aec2e25`):

- Bounded variable-length MATCH `{1,N}` **crashes with heap corruption** (`free(): invalid pointer`, `malloc_consolidate()`, `corrupted size vs. prev_size`) after any DELETE on the `nodes` vertex table.
- `merge_duplicate_nodes` performs exactly such deletes every reindex.
- `CREATE OR REPLACE PROPERTY GRAPH`, `DROP PROPERTY GRAPH` + `CREATE`, `CHECKPOINT`, and a second `refresh_property_graph()` call all fail to clear the corrupted DuckPGQ internal state.
- SIGABRT in native code bypasses `try/except duckdb.Error` entirely.

This is an upstream DuckPGQ bug, not something sqlprism can work around at the SQL layer.

## Why PGQ also added no value here

`_trace_pgq` was not the performance win it looked like on paper:

1. PGQ bounded traversal — discover reachable `node_id`s
2. Recursive CTE — recover per-hop depth (PGQ doesn't expose it)
3. Enrichment JOIN — attach file/repo/relationship metadata

That's **three queries** vs. `_trace_cte`'s **one recursive CTE** that returns everything in a single pass. For sparse SQL dependency graphs (typical dbt/sqlmesh projects), the CTE is already fast and correct.

Also: the pre-PR PGQ path had **never actually run** in any real deployment. It used `?` bind params inside `GRAPH_TABLE MATCH`, which DuckPGQ rejects. The `except duckdb.Error` clause caught the rejection on every call and silently fell through to CTE. The "always falls back" warning wasn't a bug hiding a fix — it was the correct, safe behavior masking a native crash on realistic data.

PGQ remains in use where it genuinely earns its keep: `find_path` (`ANY SHORTEST`), `pagerank`, `weakly_connected_component`, `local_clustering_coefficient`.

## Impact on #112 acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | DuckPGQ traces succeed without falling back to CTE | Moot — PGQ removed from trace path. Trace goes straight to CTE. |
| 2 | dbt test nodes and CTEs filtered from trace/reference results | Done via `_is_noise_node`. |
| 3 | jaffle-mesh precision improves | Expected — the precision win comes from #2, not from PGQ. |

## Changes

- Delete `GraphDB._trace_pgq` (~130 lines).
- Simplify `query_trace` dispatcher: drop `has_pgq`/`use_pgq` branch, always call `_trace_cte`.
- Keep `_is_noise_node` filtering on trace and reference results.
- Remove now-obsolete `test_trace_pgq_cte_parity`.

## Test plan

- [x] 549 tests pass locally (indexer, parser, conventions, renderers, graph, mcp_tools, pr_impact).
- [x] Previously crashing `test_trace_dependencies_downstream` and `test_trace_dependencies_upstream` now pass.
- [x] `_is_noise_node` tests still pass (trace and references).
- [x] Lint clean (`ruff check`).

Closes #112
