### PR TITLE
fix-99-skip-jinja-sql

### DIFF
--- a/src/sqlprism/core/indexer.py
+++ b/src/sqlprism/core/indexer.py
@@ -129,6 +129,7 @@ class Indexer:
             "columns_added": 0,
             "lineage_chains": 0,
             "column_usage_dropped": 0,
+            "files_skipped_jinja": 0,
             "parse_errors": [],
         }
 
@@ -157,6 +158,18 @@ class Indexer:
                 stats["parse_errors"].append(f"{rel_path}: unreadable (OS/permission error)")
                 continue
             checksum = current_files[rel_path]
+
+            # Jinja-templated SQL (e.g. bigquery-etl sql_generators/) is not
+            # deployable SQL — record the checksum but skip parsing so the
+            # index isn't polluted with partially-parsed template nodes.
+            if _contains_jinja(content):
+                logger.debug("Skipping Jinja-templated SQL file: %s", rel_path)
+                stats["files_skipped_jinja"] += 1
+                with self.graph.write_transaction():
+                    if rel_path in changed_set:
+                        self.graph.delete_file_data(repo_id, rel_path)
+                    self.graph.insert_file(repo_id, rel_path, "sql", checksum)
+                continue
 
             # Parse — pass schema catalog for SELECT * lineage expansion
             result = parser.parse(rel_path, content, schema=schema_catalog)
@@ -1177,6 +1190,19 @@ class Indexer:
             return [f.strip() for f in result.stdout.strip().split("\n") if f.strip() and is_sql_file(f.strip())]
         except (subprocess.TimeoutExpired, FileNotFoundError):
             return []
+
+
+_JINJA_MARKERS = ("{{", "{%")
+
+
+def _contains_jinja(content: str) -> bool:
+    """Detect Jinja template markers in SQL content.
+
+    Returns True if the content contains ``{{`` expression or ``{%`` statement
+    markers — a signal that the file is a SQL generator template rather than
+    deployable SQL.
+    """
+    return any(marker in content for marker in _JINJA_MARKERS)
 
 
 def _resolve_dialect(

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -425,6 +425,44 @@ def test_reindex_with_dialect_overrides(tmp_path):
     db.close()
 
 
+def test_reindex_skips_jinja_templated_sql(tmp_path):
+    """Files containing Jinja markers are skipped, not parsed."""
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = tmp_path / "jinja_repo"
+    repo_dir.mkdir()
+    (repo_dir / "clean.sql").write_text("CREATE TABLE orders (id INT, amount DECIMAL)")
+    (repo_dir / "expr_template.sql").write_text(
+        "CREATE OR REPLACE VIEW {{ project }}.analytics.orders AS SELECT * FROM raw.orders"
+    )
+    (repo_dir / "block_template.sql").write_text(
+        "SELECT {% for col in columns %}{{ col }},{% endfor %} 1 FROM t"
+    )
+
+    db = GraphDB()
+    indexer = Indexer(db)
+
+    stats = indexer.reindex_repo("jinja", str(repo_dir))
+    assert stats["files_scanned"] == 3
+    assert stats["files_added"] == 3
+    assert stats["files_skipped_jinja"] == 2
+    # Only clean.sql contributes nodes
+    nodes = db.query_search("orders")
+    assert nodes["total_count"] >= 1
+    # No nodes from the Jinja files (e.g. no `analytics` view, no template CTE names)
+    raw_nodes = db.query_search("analytics")
+    assert raw_nodes["total_count"] == 0
+
+    # Second reindex — skipped files have checksums recorded, so nothing is re-read
+    stats2 = indexer.reindex_repo("jinja", str(repo_dir))
+    assert stats2["files_added"] == 0
+    assert stats2["files_changed"] == 0
+    assert stats2["files_skipped_jinja"] == 0
+
+    db.close()
+
+
 # ── P6.3: MCP tool + integration tests ──
 
 


### PR DESCRIPTION
Closes #99

## Summary
- Detect `{{` or `{%` markers in `.sql` files during plain reindex
- Skip them with a debug-level log instead of letting sqlglot emit partial-parse warnings
- Record the checksum so subsequent reindex runs don't re-read the file
- Track count as `files_skipped_jinja` in stats

Rendering Jinja with a permissive undefined / variable supply will be tracked in a separate ticket.

## Test Plan
| Scenario | Status |
| --- | --- |
| File with `{{ project }}` skipped during reindex | passing |
| File with `{% for %}` block skipped during reindex | passing |
| Clean SQL still indexed normally in same repo | passing |
| `files_skipped_jinja` count in stats | passing |
| Re-running reindex doesn't re-read skipped files | passing |