### PR TITLE
fix-96-dbt-manifest-edges

### DIFF
--- a/src/sqlprism/languages/dbt.py
+++ b/src/sqlprism/languages/dbt.py
@@ -17,6 +17,7 @@ The dbt command can be customised (e.g. "uvx --with dbt-starrocks dbt" or
 just "dbt" if globally installed).
 """
 
+import json
 import logging
 import shlex
 import subprocess
@@ -25,7 +26,7 @@ from pathlib import Path
 from sqlprism.languages.sql import SqlParser
 from sqlprism.languages.sqlmesh import _validate_command
 from sqlprism.languages.utils import build_env, enrich_nodes, find_venv_dir
-from sqlprism.types import ColumnDefResult, ParseResult
+from sqlprism.types import ColumnDefResult, EdgeResult, ParseResult
 
 logger = logging.getLogger(__name__)
 
@@ -208,7 +209,133 @@ class DbtRenderer:
 
             results[rel_path] = result
 
+        # Merge in authoritative ref/source edges from the dbt manifest so
+        # model→model relationships survive the loss of `ref()` context
+        # during compilation (including cross-project mesh refs).
+        manifest_edges = self._extract_manifest_edges(project_path, project_name)
+        for rel_path, extra_edges in manifest_edges.items():
+            pr = results.get(rel_path)
+            if pr is None:
+                continue
+            existing = {
+                (e.source_name, e.source_kind, e.target_name, e.target_kind, e.relationship)
+                for e in pr.edges
+            }
+            for edge in extra_edges:
+                key = (
+                    edge.source_name,
+                    edge.source_kind,
+                    edge.target_name,
+                    edge.target_kind,
+                    edge.relationship,
+                )
+                if key not in existing:
+                    pr.edges.append(edge)
+                    existing.add(key)
+
         return results
+
+    def _extract_manifest_edges(
+        self, project_path: Path, project_name: str
+    ) -> dict[str, list[EdgeResult]]:
+        """Read ``target/manifest.json`` and derive ref/source edges for each model.
+
+        dbt's manifest preserves the logical dependency graph expressed via
+        ``ref()`` and ``source()`` — information that is lost when Jinja is
+        compiled to SQL. For each model owned by ``project_name``, emit an
+        edge per entry in ``depends_on.nodes`` pointing at the referenced
+        model (or source's physical ``identifier``).
+
+        Edges are keyed by the model's ``path`` from the manifest, which
+        matches the ``rel_path`` used by ``_compile_and_parse`` results.
+
+        Returns an empty dict if the manifest is missing or unreadable.
+        """
+        manifest_path = project_path / "target" / "manifest.json"
+        if not manifest_path.exists():
+            return {}
+
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("Cannot read dbt manifest %s: %s", manifest_path, e)
+            return {}
+
+        nodes = manifest.get("nodes") or {}
+        sources = manifest.get("sources") or {}
+
+        def _resolve_dep(key: str) -> tuple[str, str] | None:
+            """Resolve a manifest dep key to (target_name, context).
+
+            Prefers the node/source entry for accurate naming (sources may
+            have an ``identifier`` that differs from ``name``). Falls back
+            to the last segment of the key so that disabled models or
+            partial manifests still yield an edge rather than a silent drop.
+            """
+            if key in nodes:
+                dep = nodes[key]
+                if dep.get("resource_type") in ("model", "seed", "snapshot"):
+                    dep_name = dep.get("name")
+                    if dep_name:
+                        return dep_name, "ref()"
+            if key in sources:
+                dep = sources[key]
+                dep_name = dep.get("identifier") or dep.get("name")
+                if dep_name:
+                    return dep_name, "source()"
+            # Fallback: parse from the key. Formats:
+            #   model|seed|snapshot.<pkg>.<name>
+            #   source.<pkg>.<source_name>.<table>
+            parts = key.split(".")
+            if len(parts) < 3:
+                return None
+            kind = parts[0]
+            if kind == "source" and len(parts) >= 4:
+                return parts[-1], "source()"
+            if kind in ("model", "seed", "snapshot"):
+                return parts[-1], "ref()"
+            return None
+
+        edges_by_path: dict[str, list[EdgeResult]] = {}
+        for node in nodes.values():
+            if node.get("resource_type") != "model":
+                continue
+            if node.get("package_name") != project_name:
+                continue
+
+            model_name = node.get("name")
+            rel_path = node.get("path")
+            if not model_name or not rel_path:
+                continue
+
+            deps = (node.get("depends_on") or {}).get("nodes") or []
+            edges: list[EdgeResult] = []
+            seen: set[tuple[str, str]] = set()
+            for dep_key in deps:
+                resolved = _resolve_dep(dep_key)
+                if resolved is None:
+                    continue
+                target_name, context = resolved
+                if target_name == model_name:
+                    continue
+                key = (target_name, context)
+                if key in seen:
+                    continue
+                seen.add(key)
+                edges.append(
+                    EdgeResult(
+                        source_name=model_name,
+                        source_kind="query",
+                        target_name=target_name,
+                        target_kind="table",
+                        relationship="references",
+                        context=context,
+                    )
+                )
+            if edges:
+                edges_by_path[rel_path] = edges
+
+        return edges_by_path
 
     def _run_dbt_compile(
         self,

--- a/src/sqlprism/languages/dbt.py
+++ b/src/sqlprism/languages/dbt.py
@@ -19,6 +19,7 @@ just "dbt" if globally installed).
 
 import json
 import logging
+import os
 import shlex
 import subprocess
 from pathlib import Path
@@ -171,8 +172,9 @@ class DbtRenderer:
         # Read dbt_project.yml to get the project name (for compiled path)
         project_name = self._get_project_name(project_path)
 
-        # Read compiled SQL files from target/compiled/<project_name>/models/
-        compiled_dir = project_path / "target" / "compiled" / project_name / "models"
+        # Read compiled SQL files from <target-path>/compiled/<project_name>/models/
+        target_dir = self._resolve_target_dir(project_path)
+        compiled_dir = target_dir / "compiled" / project_name / "models"
         if not compiled_dir.exists():
             return {}
 
@@ -212,13 +214,19 @@ class DbtRenderer:
         # Merge in authoritative ref/source edges from the dbt manifest so
         # model→model relationships survive the loss of `ref()` context
         # during compilation (including cross-project mesh refs).
-        manifest_edges = self._extract_manifest_edges(project_path, project_name)
+        manifest_edges = self._extract_manifest_edges(
+            project_path, project_name, parser, select=select
+        )
         for rel_path, extra_edges in manifest_edges.items():
             pr = results.get(rel_path)
             if pr is None:
                 continue
+            # Dedup by full tuple including context so ref()/source() tags
+            # coexist with parser-extracted "FROM clause" edges rather than
+            # being silently dropped on identical name match.
             existing = {
-                (e.source_name, e.source_kind, e.target_name, e.target_kind, e.relationship)
+                (e.source_name, e.source_kind, e.target_name, e.target_kind,
+                 e.relationship, e.context)
                 for e in pr.edges
             }
             for edge in extra_edges:
@@ -228,6 +236,7 @@ class DbtRenderer:
                     edge.target_name,
                     edge.target_kind,
                     edge.relationship,
+                    edge.context,
                 )
                 if key not in existing:
                     pr.edges.append(edge)
@@ -235,65 +244,124 @@ class DbtRenderer:
 
         return results
 
+    def _resolve_target_dir(self, project_path: Path) -> Path:
+        """Resolve dbt's target directory path.
+
+        Order of precedence: ``DBT_TARGET_PATH`` env var, then ``target-path``
+        in ``dbt_project.yml``, then the default ``target``. Returned path is
+        absolute (resolved against ``project_path`` when relative).
+        """
+        env_path = os.environ.get("DBT_TARGET_PATH")
+        if env_path:
+            p = Path(env_path)
+            return p if p.is_absolute() else project_path / p
+
+        configured: str | None = None
+        try:
+            import yaml
+
+            data = yaml.safe_load((project_path / "dbt_project.yml").read_text())
+            if isinstance(data, dict):
+                value = data.get("target-path")
+                if isinstance(value, str):
+                    configured = value
+        except (ImportError, OSError, Exception):
+            pass
+
+        if configured:
+            p = Path(configured)
+            return p if p.is_absolute() else project_path / p
+
+        return project_path / "target"
+
     def _extract_manifest_edges(
-        self, project_path: Path, project_name: str
+        self,
+        project_path: Path,
+        project_name: str,
+        parser: SqlParser,
+        select: list[str] | None = None,
     ) -> dict[str, list[EdgeResult]]:
-        """Read ``target/manifest.json`` and derive ref/source edges for each model.
+        """Read ``<target-path>/manifest.json`` and derive ref/source edges per model.
 
         dbt's manifest preserves the logical dependency graph expressed via
         ``ref()`` and ``source()`` — information that is lost when Jinja is
         compiled to SQL. For each model owned by ``project_name``, emit an
-        edge per entry in ``depends_on.nodes`` pointing at the referenced
-        model (or source's physical ``identifier``).
+        edge per entry in ``depends_on.nodes`` (unioned with
+        ``depends_on.public_nodes`` for mesh-across-dbt-versions safety)
+        pointing at the referenced model (or a source's physical
+        ``identifier``).
+
+        Names are normalized through ``parser._normalize_identifier`` so the
+        emitted edges line up with the nodes the SQL parser creates under
+        case-folding dialects (Snowflake uppercase, DuckDB/Postgres lowercase).
 
         Edges are keyed by the model's ``path`` from the manifest, which
         matches the ``rel_path`` used by ``_compile_and_parse`` results.
 
+        Args:
+            project_path: Absolute path to the dbt project directory.
+            project_name: ``name`` field from ``dbt_project.yml``.
+            parser: The ``SqlParser`` used to parse compiled SQL — provides
+                dialect-aware identifier normalization.
+            select: If non-empty, only emit edges for models whose name is
+                in this list (matches the ``--select`` behaviour of
+                ``render_models``).
+
         Returns an empty dict if the manifest is missing or unreadable.
         """
-        manifest_path = project_path / "target" / "manifest.json"
+        manifest_path = self._resolve_target_dir(project_path) / "manifest.json"
         if not manifest_path.exists():
             return {}
 
         try:
             manifest = json.loads(manifest_path.read_text())
         except (OSError, json.JSONDecodeError) as e:
-            logger.warning("Cannot read dbt manifest %s: %s", manifest_path, e)
+            logger.error(
+                "Cannot read dbt manifest %s: %s — graph lineage will be incomplete "
+                "(ref()/source() edges unavailable)",
+                manifest_path,
+                e,
+            )
             return {}
 
         nodes = manifest.get("nodes") or {}
         sources = manifest.get("sources") or {}
+        selected = set(select) if select else None
+
+        def _norm(name: str) -> str:
+            return parser._normalize_identifier(name) if name else name
 
         def _resolve_dep(key: str) -> tuple[str, str] | None:
             """Resolve a manifest dep key to (target_name, context).
 
             Prefers the node/source entry for accurate naming (sources may
             have an ``identifier`` that differs from ``name``). Falls back
-            to the last segment of the key so that disabled models or
-            partial manifests still yield an edge rather than a silent drop.
+            to the last segment of the key — strictly validated — so that
+            disabled models or partial manifests still yield an edge rather
+            than a silent drop.
             """
             if key in nodes:
                 dep = nodes[key]
                 if dep.get("resource_type") in ("model", "seed", "snapshot"):
                     dep_name = dep.get("name")
                     if dep_name:
-                        return dep_name, "ref()"
+                        return _norm(dep_name), "ref()"
             if key in sources:
                 dep = sources[key]
                 dep_name = dep.get("identifier") or dep.get("name")
                 if dep_name:
-                    return dep_name, "source()"
-            # Fallback: parse from the key. Formats:
-            #   model|seed|snapshot.<pkg>.<name>
-            #   source.<pkg>.<source_name>.<table>
+                    return _norm(dep_name), "source()"
+            # Strict fallback — key shapes:
+            #   model|seed|snapshot.<pkg>.<name>        (3 parts)
+            #   source.<pkg>.<source_name>.<table>      (4 parts)
             parts = key.split(".")
-            if len(parts) < 3:
-                return None
-            kind = parts[0]
-            if kind == "source" and len(parts) >= 4:
-                return parts[-1], "source()"
-            if kind in ("model", "seed", "snapshot"):
-                return parts[-1], "ref()"
+            kind = parts[0] if parts else ""
+            if kind == "source" and len(parts) == 4:
+                logger.debug("manifest dep %s resolved via fallback", key)
+                return _norm(parts[-1]), "source()"
+            if kind in ("model", "seed", "snapshot") and len(parts) == 3:
+                logger.debug("manifest dep %s resolved via fallback", key)
+                return _norm(parts[-1]), "ref()"
             return None
 
         edges_by_path: dict[str, list[EdgeResult]] = {}
@@ -303,12 +371,23 @@ class DbtRenderer:
             if node.get("package_name") != project_name:
                 continue
 
-            model_name = node.get("name")
+            raw_name = node.get("name")
             rel_path = node.get("path")
-            if not model_name or not rel_path:
+            if not raw_name or not rel_path:
+                continue
+            if selected is not None and raw_name not in selected:
                 continue
 
-            deps = (node.get("depends_on") or {}).get("nodes") or []
+            # Align source_name with the SQL parser's file_stem so edges
+            # collapse onto the same node the parser creates for this model.
+            source_name = _norm(Path(rel_path).stem)
+
+            deps_obj = node.get("depends_on") or {}
+            deps = list(deps_obj.get("nodes") or [])
+            # Some dbt versions expose cross-project mesh refs via
+            # `public_nodes`; union for defensive forward-compat.
+            deps.extend(deps_obj.get("public_nodes") or [])
+
             edges: list[EdgeResult] = []
             seen: set[tuple[str, str]] = set()
             for dep_key in deps:
@@ -316,15 +395,16 @@ class DbtRenderer:
                 if resolved is None:
                     continue
                 target_name, context = resolved
-                if target_name == model_name:
+                # dbt shouldn't list self-deps, but guard against malformed manifests.
+                if target_name == source_name:
                     continue
-                key = (target_name, context)
-                if key in seen:
+                dedup_key = (target_name, context)
+                if dedup_key in seen:
                     continue
-                seen.add(key)
+                seen.add(dedup_key)
                 edges.append(
                     EdgeResult(
-                        source_name=model_name,
+                        source_name=source_name,
                         source_kind="query",
                         target_name=target_name,
                         target_kind="table",

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1427,6 +1427,85 @@ def test_reindex_files_dbt_model(tmp_path):
     db.close()
 
 
+def test_reindex_dbt_manifest_edges_end_to_end(tmp_path):
+    """Issue #96: reindex_dbt persists manifest-derived ref edges into the graph.
+
+    Builds a fake dbt project with a compiled `orders.sql` and `stg_orders.sql`
+    plus a manifest.json that declares `orders` depends on `stg_orders`. After
+    `reindex_dbt`, `query_references("stg_orders", direction="inbound")` must
+    surface `orders` as a consumer — the behavioural acceptance criterion
+    from the issue body.
+    """
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = tmp_path / "dbt_proj"
+    repo_dir.mkdir()
+    (repo_dir / "dbt_project.yml").write_text("name: my_proj\n")
+    (repo_dir / ".venv").mkdir()
+
+    compiled = repo_dir / "target" / "compiled" / "my_proj" / "models"
+    (compiled / "staging").mkdir(parents=True)
+    (compiled / "marts").mkdir(parents=True)
+    # Compiled SQL resolves to a physical schema unrelated to the model name —
+    # the parser can't recover the logical ref from this alone; manifest must.
+    (compiled / "staging" / "stg_orders.sql").write_text(
+        'SELECT id FROM "raw"."raw_orders"'
+    )
+    (compiled / "marts" / "orders.sql").write_text(
+        'SELECT * FROM "analytics_prod"."stg_orders"'
+    )
+
+    manifest = {
+        "nodes": {
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "marts/orders.sql",
+                "depends_on": {"nodes": ["model.my_proj.stg_orders"]},
+            },
+            "model.my_proj.stg_orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "stg_orders",
+                "path": "staging/stg_orders.sql",
+                "depends_on": {"nodes": ["source.my_proj.raw.raw_orders"]},
+            },
+        },
+        "sources": {
+            "source.my_proj.raw.raw_orders": {
+                "name": "raw_orders",
+                "identifier": "raw_orders",
+            },
+        },
+    }
+    (repo_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    db = GraphDB()
+    indexer = Indexer(db)
+
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        stats = indexer.reindex_dbt(
+            repo_name="jaffle", project_path=str(repo_dir), dialect="duckdb"
+        )
+
+    assert stats["models_compiled"] == 2
+    assert stats["edges_added"] > 0
+
+    # The behavioural assertion from issue #96: stg_orders has `orders` as
+    # an inbound model consumer, not just its test/materialization nodes.
+    refs = db.query_references("stg_orders", direction="inbound", include_snippets=False)
+    inbound_names = {r["name"] for r in refs["inbound"]}
+    assert "orders" in inbound_names, f"Expected 'orders' in inbound refs, got {inbound_names}"
+
+    db.close()
+
+
 def test_reindex_files_sqlmesh_model(tmp_path):
     """reindex_files() renders a sqlmesh model via render_models() and inserts the result."""
     from unittest.mock import patch

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,5 +1,7 @@
 """Tests for dbt and sqlmesh renderer utilities (Phase 5.2)."""
 
+from pathlib import Path
+
 import pytest
 
 from sqlprism.languages.dbt import DbtRenderer
@@ -208,6 +210,11 @@ def test_dbt_render_project_success(tmp_path):
             assert node.metadata["dbt_model"] == rel_path
 
 
+def _write_manifest(tmp_path: Path, manifest: dict) -> None:
+    (tmp_path / "target").mkdir(exist_ok=True)
+    (tmp_path / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+
 def test_dbt_extract_manifest_edges(tmp_path):
     """Unit test: manifest.json is parsed into ref/source EdgeResults per model."""
     manifest = {
@@ -221,6 +228,8 @@ def test_dbt_extract_manifest_edges(tmp_path):
                     "nodes": [
                         "model.my_proj.stg_orders",
                         "source.my_proj.raw.raw_orders",
+                        "seed.my_proj.countries",
+                        "snapshot.my_proj.customers_snapshot",
                     ],
                 },
             },
@@ -230,6 +239,33 @@ def test_dbt_extract_manifest_edges(tmp_path):
                 "name": "stg_orders",
                 "path": "staging/stg_orders.sql",
                 "depends_on": {"nodes": ["source.my_proj.raw.raw_orders"]},
+            },
+            # Model with zero deps — excluded from edges_by_path since no edges emitted
+            "model.my_proj.static_lookup": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "static_lookup",
+                "path": "marts/static_lookup.sql",
+                "depends_on": {"nodes": []},
+            },
+            # Model with no depends_on key at all — handled without crashing
+            "model.my_proj.no_depends": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "no_depends",
+                "path": "marts/no_depends.sql",
+            },
+            "seed.my_proj.countries": {
+                "resource_type": "seed",
+                "package_name": "my_proj",
+                "name": "countries",
+                "path": "seeds/countries.csv",
+            },
+            "snapshot.my_proj.customers_snapshot": {
+                "resource_type": "snapshot",
+                "package_name": "my_proj",
+                "name": "customers_snapshot",
+                "path": "snapshots/customers_snapshot.sql",
             },
             # Test node — should not appear as a source of ref edges
             "test.my_proj.not_null_stg_orders_id": {
@@ -255,36 +291,192 @@ def test_dbt_extract_manifest_edges(tmp_path):
             },
         },
     }
-
-    (tmp_path / "target").mkdir()
-    (tmp_path / "target" / "manifest.json").write_text(json.dumps(manifest))
+    _write_manifest(tmp_path, manifest)
 
     renderer = DbtRenderer()
-    edges_by_path = renderer._extract_manifest_edges(tmp_path, "my_proj")
+    edges_by_path = renderer._extract_manifest_edges(
+        tmp_path, "my_proj", renderer.sql_parser
+    )
 
-    # Two owned models → two entries
+    # Only the two owned models with non-empty deps appear as keys.
     assert set(edges_by_path.keys()) == {"marts/orders.sql", "staging/stg_orders.sql"}
 
-    orders_edges = edges_by_path["marts/orders.sql"]
-    orders_targets = {(e.target_name, e.context) for e in orders_edges}
-    assert orders_targets == {("stg_orders", "ref()"), ("raw_orders", "source()")}
+    orders_targets = {
+        (e.target_name, e.context) for e in edges_by_path["marts/orders.sql"]
+    }
+    assert orders_targets == {
+        ("stg_orders", "ref()"),
+        ("raw_orders", "source()"),
+        ("countries", "ref()"),
+        ("customers_snapshot", "ref()"),
+    }
 
-    for edge in orders_edges:
+    for edge in edges_by_path["marts/orders.sql"]:
         assert edge.source_name == "orders"
         assert edge.source_kind == "query"
         assert edge.target_kind == "table"
         assert edge.relationship == "references"
 
-    # Test nodes and foreign-project models are NOT emitted as sources
-    for path in edges_by_path:
-        assert "not_null" not in path
-        assert "shared" not in path
-
 
 def test_dbt_extract_manifest_edges_missing_file(tmp_path):
-    """Returns empty dict when target/manifest.json does not exist."""
+    """Returns empty dict when manifest.json does not exist."""
     renderer = DbtRenderer()
-    assert renderer._extract_manifest_edges(tmp_path, "my_proj") == {}
+    assert (
+        renderer._extract_manifest_edges(tmp_path, "my_proj", renderer.sql_parser) == {}
+    )
+
+
+def test_dbt_extract_manifest_edges_malformed_json(tmp_path, caplog):
+    """Malformed manifest.json returns {} and logs an error."""
+    (tmp_path / "target").mkdir()
+    (tmp_path / "target" / "manifest.json").write_text("not-json-garbage-{{")
+
+    renderer = DbtRenderer()
+    with caplog.at_level("ERROR", logger="sqlprism.languages.dbt"):
+        result = renderer._extract_manifest_edges(
+            tmp_path, "my_proj", renderer.sql_parser
+        )
+    assert result == {}
+    assert any("manifest" in rec.message.lower() for rec in caplog.records)
+
+
+def test_dbt_extract_manifest_edges_only_foreign_packages(tmp_path):
+    """Manifest with only foreign-package models returns {}."""
+    manifest = {
+        "nodes": {
+            "model.upstream.shared": {
+                "resource_type": "model",
+                "package_name": "upstream",
+                "name": "shared",
+                "path": "models/shared.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        "sources": {},
+    }
+    _write_manifest(tmp_path, manifest)
+
+    renderer = DbtRenderer()
+    assert (
+        renderer._extract_manifest_edges(tmp_path, "my_proj", renderer.sql_parser) == {}
+    )
+
+
+def test_dbt_extract_manifest_edges_snowflake_case_folding(tmp_path):
+    """Snowflake dialect uppercases identifiers so edges match parser-created nodes."""
+    from sqlprism.languages.sql import SqlParser
+
+    manifest = {
+        "nodes": {
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "marts/orders.sql",
+                "depends_on": {"nodes": ["model.my_proj.stg_orders"]},
+            },
+            "model.my_proj.stg_orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "stg_orders",
+                "path": "staging/stg_orders.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        "sources": {},
+    }
+    _write_manifest(tmp_path, manifest)
+
+    renderer = DbtRenderer()
+    sf_parser = SqlParser(dialect="snowflake")
+    edges_by_path = renderer._extract_manifest_edges(tmp_path, "my_proj", sf_parser)
+
+    edge = edges_by_path["marts/orders.sql"][0]
+    assert edge.source_name == "ORDERS"
+    assert edge.target_name == "STG_ORDERS"
+
+
+def test_dbt_extract_manifest_edges_select_short_circuits(tmp_path):
+    """When `select` is passed, only listed models produce edges."""
+    manifest = {
+        "nodes": {
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "marts/orders.sql",
+                "depends_on": {"nodes": ["model.my_proj.stg_orders"]},
+            },
+            "model.my_proj.customers": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "customers",
+                "path": "marts/customers.sql",
+                "depends_on": {"nodes": ["model.my_proj.stg_customers"]},
+            },
+        },
+        "sources": {},
+    }
+    _write_manifest(tmp_path, manifest)
+
+    renderer = DbtRenderer()
+    edges = renderer._extract_manifest_edges(
+        tmp_path, "my_proj", renderer.sql_parser, select=["orders"]
+    )
+    assert set(edges.keys()) == {"marts/orders.sql"}
+
+
+def test_dbt_extract_manifest_edges_public_nodes_union(tmp_path):
+    """Cross-project mesh refs in `public_nodes` are unioned with `nodes`."""
+    manifest = {
+        "nodes": {
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "marts/orders.sql",
+                "depends_on": {
+                    "nodes": [],
+                    "public_nodes": ["model.upstream_proj.stg_orders"],
+                },
+            },
+        },
+        "sources": {},
+    }
+    _write_manifest(tmp_path, manifest)
+
+    renderer = DbtRenderer()
+    edges = renderer._extract_manifest_edges(
+        tmp_path, "my_proj", renderer.sql_parser
+    )
+    targets = {(e.target_name, e.context) for e in edges["marts/orders.sql"]}
+    assert targets == {("stg_orders", "ref()")}
+
+
+def test_dbt_extract_manifest_edges_custom_target_path(tmp_path, monkeypatch):
+    """DBT_TARGET_PATH env var redirects manifest lookup."""
+    custom_target = tmp_path / "custom-target"
+    custom_target.mkdir()
+    manifest = {
+        "nodes": {
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "marts/orders.sql",
+                "depends_on": {"nodes": ["model.my_proj.stg_orders"]},
+            },
+        },
+        "sources": {},
+    }
+    (custom_target / "manifest.json").write_text(json.dumps(manifest))
+
+    monkeypatch.setenv("DBT_TARGET_PATH", str(custom_target))
+    renderer = DbtRenderer()
+    edges = renderer._extract_manifest_edges(
+        tmp_path, "my_proj", renderer.sql_parser
+    )
+    assert "marts/orders.sql" in edges
 
 
 def test_dbt_render_project_merges_manifest_edges(tmp_path):
@@ -294,11 +486,10 @@ def test_dbt_render_project_merges_manifest_edges(tmp_path):
 
     compiled_dir = tmp_path / "target" / "compiled" / "my_proj" / "models"
     compiled_dir.mkdir(parents=True)
-    # Compiled SQL references only raw_orders — manifest must add the logical
-    # ref to stg_orders (e.g. a macro-derived ref the parser can't see).
+    # Realistic dbt compiled output: source() compiles to quoted schema-qualified name.
     (compiled_dir / "marts").mkdir()
     (compiled_dir / "marts" / "orders.sql").write_text(
-        "SELECT id FROM raw_orders"
+        'SELECT id FROM "raw"."raw_orders"'
     )
 
     manifest = {
@@ -330,7 +521,7 @@ def test_dbt_render_project_merges_manifest_edges(tmp_path):
             },
         },
     }
-    (tmp_path / "target" / "manifest.json").write_text(json.dumps(manifest))
+    _write_manifest(tmp_path, manifest)
 
     renderer = DbtRenderer()
     with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
@@ -350,10 +541,16 @@ def test_dbt_render_project_merges_manifest_edges(tmp_path):
     assert edge.relationship == "references"
     assert edge.context == "ref()"
 
-    # Parser already extracted raw_orders from the FROM clause — manifest's
-    # duplicate source() edge is deduped so we keep exactly one.
+    # Parser emits raw_orders with context="FROM clause"; manifest emits the
+    # same edge with context="source()". Dedup key includes context so both
+    # coexist — preserving the source() semantic tag without losing the
+    # parser's positional info.
     raw_edges = [e for e in parse_result.edges if e.target_name == "raw_orders"]
-    assert len(raw_edges) == 1
+    raw_contexts = {e.context for e in raw_edges}
+    assert raw_contexts == {"FROM clause", "source()"}
+    for e in raw_edges:
+        assert e.source_kind == "query"
+        assert e.relationship == "references"
 
 
 # ── SqlMeshRenderer.render_project mocked tests ──

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -208,6 +208,154 @@ def test_dbt_render_project_success(tmp_path):
             assert node.metadata["dbt_model"] == rel_path
 
 
+def test_dbt_extract_manifest_edges(tmp_path):
+    """Unit test: manifest.json is parsed into ref/source EdgeResults per model."""
+    manifest = {
+        "nodes": {
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "marts/orders.sql",
+                "depends_on": {
+                    "nodes": [
+                        "model.my_proj.stg_orders",
+                        "source.my_proj.raw.raw_orders",
+                    ],
+                },
+            },
+            "model.my_proj.stg_orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "stg_orders",
+                "path": "staging/stg_orders.sql",
+                "depends_on": {"nodes": ["source.my_proj.raw.raw_orders"]},
+            },
+            # Test node — should not appear as a source of ref edges
+            "test.my_proj.not_null_stg_orders_id": {
+                "resource_type": "test",
+                "package_name": "my_proj",
+                "name": "not_null_stg_orders_id",
+                "path": "staging/stg_orders.yml/not_null_stg_orders_id.sql",
+                "depends_on": {"nodes": ["model.my_proj.stg_orders"]},
+            },
+            # Foreign-package model — skipped (belongs to another project)
+            "model.other_proj.shared": {
+                "resource_type": "model",
+                "package_name": "other_proj",
+                "name": "shared",
+                "path": "marts/shared.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        "sources": {
+            "source.my_proj.raw.raw_orders": {
+                "name": "raw_orders",
+                "identifier": "raw_orders",
+            },
+        },
+    }
+
+    (tmp_path / "target").mkdir()
+    (tmp_path / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    renderer = DbtRenderer()
+    edges_by_path = renderer._extract_manifest_edges(tmp_path, "my_proj")
+
+    # Two owned models → two entries
+    assert set(edges_by_path.keys()) == {"marts/orders.sql", "staging/stg_orders.sql"}
+
+    orders_edges = edges_by_path["marts/orders.sql"]
+    orders_targets = {(e.target_name, e.context) for e in orders_edges}
+    assert orders_targets == {("stg_orders", "ref()"), ("raw_orders", "source()")}
+
+    for edge in orders_edges:
+        assert edge.source_name == "orders"
+        assert edge.source_kind == "query"
+        assert edge.target_kind == "table"
+        assert edge.relationship == "references"
+
+    # Test nodes and foreign-project models are NOT emitted as sources
+    for path in edges_by_path:
+        assert "not_null" not in path
+        assert "shared" not in path
+
+
+def test_dbt_extract_manifest_edges_missing_file(tmp_path):
+    """Returns empty dict when target/manifest.json does not exist."""
+    renderer = DbtRenderer()
+    assert renderer._extract_manifest_edges(tmp_path, "my_proj") == {}
+
+
+def test_dbt_render_project_merges_manifest_edges(tmp_path):
+    """Manifest ref edges are merged into ParseResult.edges alongside parsed SQL."""
+    (tmp_path / "dbt_project.yml").write_text("name: my_proj\n")
+    (tmp_path / ".venv").mkdir()
+
+    compiled_dir = tmp_path / "target" / "compiled" / "my_proj" / "models"
+    compiled_dir.mkdir(parents=True)
+    # Compiled SQL references only raw_orders — manifest must add the logical
+    # ref to stg_orders (e.g. a macro-derived ref the parser can't see).
+    (compiled_dir / "marts").mkdir()
+    (compiled_dir / "marts" / "orders.sql").write_text(
+        "SELECT id FROM raw_orders"
+    )
+
+    manifest = {
+        "nodes": {
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "marts/orders.sql",
+                "depends_on": {
+                    "nodes": [
+                        "model.my_proj.stg_orders",
+                        "source.my_proj.raw.raw_orders",
+                    ],
+                },
+            },
+            "model.my_proj.stg_orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "stg_orders",
+                "path": "staging/stg_orders.sql",
+                "depends_on": {"nodes": ["source.my_proj.raw.raw_orders"]},
+            },
+        },
+        "sources": {
+            "source.my_proj.raw.raw_orders": {
+                "name": "raw_orders",
+                "identifier": "raw_orders",
+            },
+        },
+    }
+    (tmp_path / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    renderer = DbtRenderer()
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        results = renderer.render_project(project_path=tmp_path)
+
+    assert "marts/orders.sql" in results
+    parse_result = results["marts/orders.sql"]
+
+    # Manifest adds the logical ref to stg_orders (not present in compiled SQL)
+    stg_orders_edges = [e for e in parse_result.edges if e.target_name == "stg_orders"]
+    assert len(stg_orders_edges) == 1
+    edge = stg_orders_edges[0]
+    assert edge.source_name == "orders"
+    assert edge.source_kind == "query"
+    assert edge.target_kind == "table"
+    assert edge.relationship == "references"
+    assert edge.context == "ref()"
+
+    # Parser already extracted raw_orders from the FROM clause — manifest's
+    # duplicate source() edge is deduped so we keep exactly one.
+    raw_edges = [e for e in parse_result.edges if e.target_name == "raw_orders"]
+    assert len(raw_edges) == 1
+
+
 # ── SqlMeshRenderer.render_project mocked tests ──
 
 


### PR DESCRIPTION
Closes #96

## Summary
- Parse `target/manifest.json` after `dbt compile` and derive authoritative `ref()` / `source()` edges from `depends_on.nodes`
- Only emit edges for models owned by the project's `package_name` — each mesh member contributes its own slice
- Merge manifest edges into each model's `ParseResult.edges` with dedup against edges the SQL parser already extracted
- Cross-project mesh refs (e.g. `finance.order_items -> platform.stg_orders`) now survive compilation; they stitch together via the existing stub-merge pass when mesh members are indexed into the same DB

## Test Plan
| Scenario | Status |
| --- | --- |
| Unit: manifest.json parsed into `EdgeResult` with ref()/source() contexts | passing |
| Unit: foreign-package models and test nodes skipped as edge sources | passing |
| Unit: missing manifest.json returns `{}` | passing |
| Integration: manifest adds ref not present in compiled SQL | passing |
| Integration: duplicate edges (parser + manifest) dedupe to one | passing |

## Out of scope (tracked separately)
Auto-discovery / auto-compile of mesh siblings from a single `reindex-dbt` invocation. Users still run `reindex-dbt` per project.

## Sanity-check against real mesh project
Against `sql-nav-bench/repos/jaffle-mesh/`:
- **platform** → 6 `source()` edges (stg_* → raw_*)
- **finance** → 7 `ref()` edges to platform's stg_* models
- **marketing** → 2 `ref()` edges to finance and platform models