### PR TITLE
chore-98-dbt-sqlmesh-missing-dep-errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Claude
 .claude/research/
 .claude/plans/
+.claude/worktrees/
 .claude/settings.local.json
 .mcp.json
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ uv run sqlprism reindex                 # index plain SQL repos
 
 For [dbt](https://www.getdbt.com/) and [SQLMesh](https://sqlmesh.com/) projects, use `reindex-dbt` and `reindex-sqlmesh` respectively. See the [CLI guide](https://darkcofy.github.io/sqlprism/guide/cli/) for full options.
 
+> **Prerequisite:** dbt and SQLMesh are **not** dependencies of sqlprism. The renderers shell out to `dbt compile` / `sqlmesh` inside the target project's own virtualenv (via `uv run` by default). Install the renderer in that project — for example `uv add dbt-core dbt-<adapter>` or `uv add sqlmesh` — before running `reindex-dbt` / `reindex-sqlmesh`. If the renderer is missing, sqlprism will raise a clear error pointing at the project directory.
+
 ### 3. Connect your MCP client
 
 **Claude Code:**

--- a/src/sqlprism/languages/dbt.py
+++ b/src/sqlprism/languages/dbt.py
@@ -451,7 +451,20 @@ class DbtRenderer:
         )
 
         if result.returncode != 0:
-            output = result.stderr.strip() or result.stdout.strip()
+            stderr = result.stderr.strip()
+            stdout = result.stdout.strip()
+            combined = f"{stderr}\n{stdout}"
+            if "Failed to spawn: dbt" in combined or (
+                "No module named" in combined and "dbt" in combined
+            ):
+                raise RuntimeError(
+                    f"dbt is not installed in the project environment at {cwd}. "
+                    "Install it in the dbt project's virtualenv "
+                    "(e.g. `uv add dbt-core dbt-<adapter>` or "
+                    "`pip install dbt-core dbt-<adapter>`), "
+                    "or point `dbt_command` at a command that can launch dbt."
+                )
+            output = stderr or stdout
             raise RuntimeError(f"dbt compile failed (exit {result.returncode}):\n{output}")
 
     def _get_project_name(self, project_path: Path) -> str:

--- a/src/sqlprism/languages/sqlmesh.py
+++ b/src/sqlprism/languages/sqlmesh.py
@@ -536,12 +536,19 @@ class SqlMeshRenderer:
 
         if result.returncode != 0:
             stderr = result.stderr.strip()
-            if "No module named" in stderr and "sqlmesh" in stderr:
+            stdout = result.stdout.strip()
+            combined = f"{stderr}\n{stdout}"
+            if (
+                ("No module named" in combined and "sqlmesh" in combined)
+                or "Failed to spawn: sqlmesh" in combined
+            ):
                 raise RuntimeError(
                     f"sqlmesh is not installed in the project environment at {cwd}. "
-                    "Install it with: pip install sqlmesh (in the project's virtualenv)"
+                    "Install it in the sqlmesh project's virtualenv "
+                    "(e.g. `uv add sqlmesh` or `pip install sqlmesh`), "
+                    "or point `sqlmesh_command` at a command that can launch sqlmesh."
                 )
-            output = stderr or result.stdout.strip()
+            output = stderr or stdout
             raise RuntimeError(f"sqlmesh render failed (exit {result.returncode}):\n{output}")
 
         output = json.loads(result.stdout)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1676,7 +1676,7 @@ def test_sqlmesh_render_missing_module_error(tmp_path, monkeypatch):
 
     import pytest
 
-    with pytest.raises(RuntimeError, match="sqlmesh is not installed"):
+    with pytest.raises(RuntimeError, match="sqlmesh is not installed") as exc_info:
         renderer._run_render_script(
             project_path=tmp_path,
             cwd=tmp_path,
@@ -1685,5 +1685,37 @@ def test_sqlmesh_render_missing_module_error(tmp_path, monkeypatch):
             gateway="local",
             dialect="duckdb",
             sqlmesh_command="python",
+            model_filter=[],
+        )
+    # Message should point at the cwd so users know which venv to fix
+    assert str(tmp_path) in str(exc_info.value)
+
+
+def test_sqlmesh_render_failed_to_spawn_error(tmp_path, monkeypatch):
+    """When sqlmesh binary isn't on PATH, 'Failed to spawn: sqlmesh' should map to the friendly error."""
+    import subprocess as sp
+
+    from sqlprism.languages.sqlmesh import SqlMeshRenderer
+
+    renderer = SqlMeshRenderer()
+
+    def fake_run(*args, **kwargs):
+        return sp.CompletedProcess(
+            args=args[0],
+            returncode=2,
+            stdout="",
+            stderr="error: Failed to spawn: sqlmesh\n  Caused by: No such file or directory",
+        )
+
+    monkeypatch.setattr(sp, "run", fake_run)
+    with pytest.raises(RuntimeError, match="sqlmesh is not installed"):
+        renderer._run_render_script(
+            project_path=tmp_path,
+            cwd=tmp_path,
+            env={},
+            variables={},
+            gateway="local",
+            dialect="duckdb",
+            sqlmesh_command="uv run sqlmesh",
             model_filter=[],
         )

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1604,6 +1604,58 @@ def test_dbt_compile_error_includes_stdout(tmp_path, monkeypatch):
         )
 
 
+def test_dbt_missing_binary_error(tmp_path, monkeypatch):
+    """When dbt isn't installed, uv reports 'Failed to spawn: dbt' — surface actionable message."""
+    import subprocess as sp
+
+    renderer = DbtRenderer()
+
+    def fake_run(*args, **kwargs):
+        return sp.CompletedProcess(
+            args=args[0],
+            returncode=2,
+            stdout="",
+            stderr="error: Failed to spawn: dbt\n  Caused by: No such file or directory (os error 2)",
+        )
+
+    monkeypatch.setattr(sp, "run", fake_run)
+    with pytest.raises(RuntimeError, match="dbt is not installed in the project environment"):
+        renderer._run_dbt_compile(
+            project_path=tmp_path,
+            profiles_dir=tmp_path,
+            cwd=tmp_path,
+            env={},
+            target=None,
+            dbt_command="uv run dbt",
+        )
+
+
+def test_dbt_missing_module_error(tmp_path, monkeypatch):
+    """ModuleNotFoundError for dbt should also trip the friendly message."""
+    import subprocess as sp
+
+    renderer = DbtRenderer()
+
+    def fake_run(*args, **kwargs):
+        return sp.CompletedProcess(
+            args=args[0],
+            returncode=1,
+            stdout="",
+            stderr="ModuleNotFoundError: No module named 'dbt'",
+        )
+
+    monkeypatch.setattr(sp, "run", fake_run)
+    with pytest.raises(RuntimeError, match="dbt is not installed in the project environment"):
+        renderer._run_dbt_compile(
+            project_path=tmp_path,
+            profiles_dir=tmp_path,
+            cwd=tmp_path,
+            env={},
+            target=None,
+            dbt_command="uv run dbt",
+        )
+
+
 def test_sqlmesh_render_missing_module_error(tmp_path, monkeypatch):
     """When sqlmesh is not installed, error message should say so clearly."""
     import subprocess as sp

--- a/tests/test_sql_parser.py
+++ b/tests/test_sql_parser.py
@@ -1456,7 +1456,9 @@ def test_bare_select_file_gets_query_node():
     result = parser.parse("stg_orders.sql", "SELECT id, name FROM customers")
     query_nodes = [n for n in result.nodes if n.kind == "query" and n.name == "stg_orders"]
     assert len(query_nodes) == 1
-    assert query_nodes[0].metadata.get("file_node") is True
+    metadata = query_nodes[0].metadata
+    assert metadata is not None
+    assert metadata.get("file_node") is True
 
 
 def test_generic_filename_uses_parent_dir():


### PR DESCRIPTION
Closes #98

## Summary
- Improve the error raised when `dbt` or `sqlmesh` is missing from the target project's venv. sqlprism shells out through `uv run` into that venv, so the current failure surfaces as a raw `Failed to spawn: dbt` / `ModuleNotFoundError` traceback.
- Phrase the two renderer errors consistently and include the cwd so users know which venv to fix.
- Document the design in the README so it's clear that dbt and sqlmesh are not sqlprism dependencies — they live in the target project.
- Drive-by: fix a pre-existing ty warning in `tests/test_sql_parser.py` and ignore `.claude/worktrees/` so ty stops scanning stale agent worktrees.

## Test Plan
| Test | Status |
|---|---|
| `test_dbt_missing_binary_error` (new — `Failed to spawn: dbt`) | passing |
| `test_dbt_missing_module_error` (new — `ModuleNotFoundError`) | passing |
| `test_dbt_compile_error_includes_stdout` (existing) | passing |
| `test_sqlmesh_render_missing_module_error` (existing, asserts cwd in message) | passing |
| `test_sqlmesh_render_failed_to_spawn_error` (new) | passing |
| `uv run ruff check .` | passing |
| `uv run ty check` | passing (0 diagnostics) |
| full `uv run pytest tests/` | 563 passed |