### PR TITLE
fix-119-cte-leak-as-tables

### DIFF
--- a/src/sqlprism/languages/dbt.py
+++ b/src/sqlprism/languages/dbt.py
@@ -185,7 +185,9 @@ class DbtRenderer:
             if selected and sql_file.stem not in selected:
                 continue
 
-            rel_path = str(sql_file.relative_to(compiled_dir))
+            # Use posix-style separators so dict keys match manifest `path`
+            # values (always forward-slash) across Windows and Unix.
+            rel_path = sql_file.relative_to(compiled_dir).as_posix()
             content = sql_file.read_text(errors="replace")
             if not content.strip():
                 continue

--- a/src/sqlprism/languages/dbt.py
+++ b/src/sqlprism/languages/dbt.py
@@ -378,9 +378,14 @@ class DbtRenderer:
             if selected is not None and raw_name not in selected:
                 continue
 
-            # Align source_name with the SQL parser's file_stem so edges
-            # collapse onto the same node the parser creates for this model.
-            source_name = _norm(Path(rel_path).stem)
+            # Align source_name/kind/schema with the `CREATE TABLE
+            # "<path-schema>"."<stem>"` node the renderer wraps around each
+            # compiled model, so manifest edges resolve to the exact table
+            # node (not a kind-relaxed fallback that may pick a CTE sharing
+            # the stem's name).
+            path_parts = rel_path.removesuffix(".sql").split("/")
+            source_name = _norm(path_parts[-1])
+            source_schema = "/".join(path_parts[:-1]) if len(path_parts) > 1 else None
 
             deps_obj = node.get("depends_on") or {}
             deps = list(deps_obj.get("nodes") or [])
@@ -405,11 +410,12 @@ class DbtRenderer:
                 edges.append(
                     EdgeResult(
                         source_name=source_name,
-                        source_kind="query",
+                        source_kind="table",
                         target_name=target_name,
                         target_kind="table",
                         relationship="references",
                         context=context,
+                        metadata={"source_schema": source_schema} if source_schema else None,
                     )
                 )
             if edges:

--- a/src/sqlprism/languages/sql.py
+++ b/src/sqlprism/languages/sql.py
@@ -217,7 +217,7 @@ class SqlParser:
         if not kind_expr:
             return
 
-        kind_str = kind_expr.upper() if isinstance(kind_expr, str) else str(kind_expr).upper()
+        kind_str = self._create_kind_str(stmt)
 
         # Unwrap Schema -> Table if needed
         table_expr = stmt.this
@@ -349,24 +349,13 @@ class SqlParser:
                     self._is_quoted_identifier(target_expr),
                 )
                 if create_target == file_stem:
-                    kind_expr = stmt.args.get("kind")
-                    kind_str = (
-                        kind_expr.upper() if isinstance(kind_expr, str)
-                        else str(kind_expr).upper() if kind_expr else ""
+                    source_kind = (
+                        "view" if "VIEW" in self._create_kind_str(stmt) else "table"
                     )
-                    source_kind = "view" if "VIEW" in kind_str else "table"
                     target_metadata = self._build_table_metadata(target_expr)
                     source_schema = target_metadata.get("schema")
 
-        # Collect CTE aliases in this statement so `FROM cte_alias` is not
-        # mistaken for an external table reference. CTE→CTE and CTE→table
-        # edges are handled by `_extract_ctes`.
-        cte_aliases: set[str] = set()
-        for cte in stmt.find_all(exp.CTE):
-            if cte.alias:
-                alias_node = cte.args.get("alias")
-                quoted = self._is_quoted_identifier(alias_node) if alias_node else False
-                cte_aliases.add(self._normalize_identifier(cte.alias, quoted))
+        edge_source_metadata = {"source_schema": source_schema} if source_schema else None
 
         for table in stmt.find_all(exp.Table):
             name = self._normalize_identifier(table.name, self._is_quoted_identifier(table))
@@ -380,11 +369,10 @@ class SqlParser:
                 if isinstance(parent, (exp.Create, exp.Schema)):
                     continue
 
-            # Skip references to CTE aliases — they are local query names,
-            # not external tables. The CTE's own references (what it FROMs)
-            # are still captured because `find_all(exp.Table)` walks into
-            # the CTE body.
-            if name in cte_aliases:
+            # Skip references to CTE aliases visible in the table's enclosing
+            # scope. A flat statement-wide check would over-suppress when a
+            # nested subquery's CTE shadows an outer-scope real table name.
+            if self._is_cte_reference(table, name):
                 continue
 
             # Avoid duplicating nodes for the same table+schema within one file (O(1) check)
@@ -406,7 +394,6 @@ class SqlParser:
                 continue
             seen_edges.add(edge_key)
 
-            edge_metadata = {"source_schema": source_schema} if source_schema else None
             edges.append(
                 EdgeResult(
                     source_name=file_stem,
@@ -415,7 +402,7 @@ class SqlParser:
                     target_kind="table",
                     relationship=relationship,
                     context=context,
-                    metadata=edge_metadata,
+                    metadata=edge_source_metadata,
                 )
             )
 
@@ -439,13 +426,7 @@ class SqlParser:
         if seen_ctes is None:
             seen_ctes = set()
 
-        # Collect all CTE names in this statement first
-        cte_names: set[str] = set()
-        for cte in stmt.find_all(exp.CTE):
-            if cte.alias:
-                alias_node = cte.args.get("alias")
-                quoted = self._is_quoted_identifier(alias_node) if alias_node else False
-                cte_names.add(self._normalize_identifier(cte.alias, quoted))
+        cte_names = self._collect_cte_aliases(stmt)
 
         for cte in stmt.find_all(exp.CTE):
             alias_node = cte.args.get("alias")
@@ -1123,6 +1104,55 @@ class SqlParser:
         if d in self._UPPERCASE_DIALECTS:
             return name.upper()
         return name
+
+    @staticmethod
+    def _create_kind_str(stmt: exp.Expression) -> str:
+        """Uppercased `kind` string of a CREATE statement, or '' if not present."""
+        kind_expr = stmt.args.get("kind") if hasattr(stmt, "args") else None
+        if not kind_expr:
+            return ""
+        return kind_expr.upper() if isinstance(kind_expr, str) else str(kind_expr).upper()
+
+    def _collect_cte_aliases(self, stmt: exp.Expression) -> set[str]:
+        """Collect every CTE alias appearing anywhere in the statement tree.
+
+        Used where flat lookup is safe (e.g. identifying CTE→CTE edges inside
+        ``_extract_ctes``). For scope-aware suppression of outer-scope table
+        references, use :meth:`_is_cte_reference` instead.
+        """
+        aliases: set[str] = set()
+        for cte in stmt.find_all(exp.CTE):
+            if not cte.alias:
+                continue
+            alias_node = cte.args.get("alias")
+            quoted = self._is_quoted_identifier(alias_node) if alias_node else False
+            aliases.add(self._normalize_identifier(cte.alias, quoted))
+        return aliases
+
+    def _is_cte_reference(self, table: exp.Table, normalized_name: str) -> bool:
+        """Return True if ``table`` references a CTE alias visible in its scope.
+
+        Walks up the AST from the table and, at each ancestor that carries a
+        ``with`` argument (i.e. a Select with an attached WITH clause), checks
+        whether that clause defines ``normalized_name``. Scope-local so an
+        inner subquery's CTE cannot mask an outer-scope real table reference.
+        """
+        node = table.parent
+        while node is not None:
+            args = getattr(node, "args", None)
+            # sqlglot stores the WITH clause under `with_` (the trailing
+            # underscore avoids colliding with the Python keyword).
+            with_clause = args.get("with") or args.get("with_") if args else None
+            if with_clause is not None:
+                for cte in with_clause.expressions:
+                    if not cte.alias:
+                        continue
+                    alias_node = cte.args.get("alias")
+                    quoted = self._is_quoted_identifier(alias_node) if alias_node else False
+                    if self._normalize_identifier(cte.alias, quoted) == normalized_name:
+                        return True
+            node = node.parent
+        return False
 
     @staticmethod
     def _is_quoted_identifier(node: exp.Expression) -> bool:

--- a/src/sqlprism/languages/sql.py
+++ b/src/sqlprism/languages/sql.py
@@ -344,6 +344,16 @@ class SqlParser:
                     self._is_quoted_identifier(target_expr),
                 )
 
+        # Collect CTE aliases in this statement so `FROM cte_alias` is not
+        # mistaken for an external table reference. CTE→CTE and CTE→table
+        # edges are handled by `_extract_ctes`.
+        cte_aliases: set[str] = set()
+        for cte in stmt.find_all(exp.CTE):
+            if cte.alias:
+                alias_node = cte.args.get("alias")
+                quoted = self._is_quoted_identifier(alias_node) if alias_node else False
+                cte_aliases.add(self._normalize_identifier(cte.alias, quoted))
+
         for table in stmt.find_all(exp.Table):
             name = self._normalize_identifier(table.name, self._is_quoted_identifier(table))
             if not name:
@@ -355,6 +365,13 @@ class SqlParser:
                 parent = table.parent
                 if isinstance(parent, (exp.Create, exp.Schema)):
                     continue
+
+            # Skip references to CTE aliases — they are local query names,
+            # not external tables. The CTE's own references (what it FROMs)
+            # are still captured because `find_all(exp.Table)` walks into
+            # the CTE body.
+            if name in cte_aliases:
+                continue
 
             # Avoid duplicating nodes for the same table+schema within one file (O(1) check)
             metadata = self._build_table_metadata(table)

--- a/src/sqlprism/languages/sql.py
+++ b/src/sqlprism/languages/sql.py
@@ -332,8 +332,13 @@ class SqlParser:
         if seen_edges is None:
             seen_edges = set()
 
-        # Identify the CREATE target so we don't double-count it as a reference
+        # Identify the CREATE target so we don't double-count it as a reference,
+        # and pull its kind/schema so the edges we emit resolve directly to the
+        # created node instead of kind-relaxed fallback (which may pick the
+        # wrong node when a CTE shares the file stem's name).
         create_target: str | None = None
+        source_kind: str = "query"
+        source_schema: str | None = None
         if isinstance(stmt, exp.Create):
             target_expr = stmt.this
             if isinstance(target_expr, exp.Schema):
@@ -343,6 +348,15 @@ class SqlParser:
                     target_expr.name,
                     self._is_quoted_identifier(target_expr),
                 )
+                if create_target == file_stem:
+                    kind_expr = stmt.args.get("kind")
+                    kind_str = (
+                        kind_expr.upper() if isinstance(kind_expr, str)
+                        else str(kind_expr).upper() if kind_expr else ""
+                    )
+                    source_kind = "view" if "VIEW" in kind_str else "table"
+                    target_metadata = self._build_table_metadata(target_expr)
+                    source_schema = target_metadata.get("schema")
 
         # Collect CTE aliases in this statement so `FROM cte_alias` is not
         # mistaken for an external table reference. CTE→CTE and CTE→table
@@ -392,14 +406,16 @@ class SqlParser:
                 continue
             seen_edges.add(edge_key)
 
+            edge_metadata = {"source_schema": source_schema} if source_schema else None
             edges.append(
                 EdgeResult(
                     source_name=file_stem,
-                    source_kind="query",
+                    source_kind=source_kind,
                     target_name=name,
                     target_kind="table",
                     relationship=relationship,
                     context=context,
+                    metadata=edge_metadata,
                 )
             )
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -313,9 +313,10 @@ def test_dbt_extract_manifest_edges(tmp_path):
 
     for edge in edges_by_path["marts/orders.sql"]:
         assert edge.source_name == "orders"
-        assert edge.source_kind == "query"
+        assert edge.source_kind == "table"
         assert edge.target_kind == "table"
         assert edge.relationship == "references"
+        assert (edge.metadata or {}).get("source_schema") == "marts"
 
 
 def test_dbt_extract_manifest_edges_missing_file(tmp_path):
@@ -536,7 +537,7 @@ def test_dbt_render_project_merges_manifest_edges(tmp_path):
     assert len(stg_orders_edges) == 1
     edge = stg_orders_edges[0]
     assert edge.source_name == "orders"
-    assert edge.source_kind == "query"
+    assert edge.source_kind == "table"
     assert edge.target_kind == "table"
     assert edge.relationship == "references"
     assert edge.context == "ref()"
@@ -549,7 +550,7 @@ def test_dbt_render_project_merges_manifest_edges(tmp_path):
     raw_contexts = {e.context for e in raw_edges}
     assert raw_contexts == {"FROM clause", "source()"}
     for e in raw_edges:
-        assert e.source_kind == "query"
+        assert e.source_kind == "table"
         assert e.relationship == "references"
 
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -319,6 +319,39 @@ def test_dbt_extract_manifest_edges(tmp_path):
         assert (edge.metadata or {}).get("source_schema") == "marts"
 
 
+def test_dbt_extract_manifest_edges_root_model_has_no_source_schema(tmp_path):
+    """A model at the project root (no subdirectory) emits edges with metadata=None."""
+    manifest = {
+        "nodes": {
+            "model.my_proj.flat_orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "flat_orders",
+                "path": "flat_orders.sql",
+                "depends_on": {"nodes": ["model.my_proj.stg_orders"]},
+            },
+            "model.my_proj.stg_orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "stg_orders",
+                "path": "staging/stg_orders.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        "sources": {},
+    }
+    _write_manifest(tmp_path, manifest)
+
+    renderer = DbtRenderer()
+    edges_by_path = renderer._extract_manifest_edges(
+        tmp_path, "my_proj", renderer.sql_parser
+    )
+    edges = edges_by_path["flat_orders.sql"]
+    assert len(edges) == 1
+    assert edges[0].source_kind == "table"
+    assert edges[0].metadata is None
+
+
 def test_dbt_extract_manifest_edges_missing_file(tmp_path):
     """Returns empty dict when manifest.json does not exist."""
     renderer = DbtRenderer()

--- a/tests/test_sql_parser.py
+++ b/tests/test_sql_parser.py
@@ -387,6 +387,82 @@ def test_cte_alias_not_indexed_as_table_reference():
     assert "stg_orders" in table_targets
     assert "order_items" in table_targets
 
+    # CTE nodes still created as first-class kind='cte' entities
+    assert {n.name for n in result.nodes if n.kind == "cte"} == cte_names
+
+    # CTE→real-table edges still flow (needed for column lineage)
+    assert any(
+        e.source_name == "orders" and e.source_kind == "cte" and e.target_name == "stg_orders"
+        for e in result.edges
+    )
+
+
+def test_create_table_wrap_with_colliding_cte_stamps_source_kind():
+    """dbt-compiled shape: CREATE TABLE wrap where a CTE name equals the file stem.
+
+    Reproduces the jaffle-mesh finance/orders bug where kind-relaxed fallback
+    landed manifest edges on the CTE node instead of the wrapped table node.
+    Verifies the new source_kind/source_schema stamping.
+    """
+    sql = (
+        'CREATE TABLE "marts"."orders" AS\n'
+        "WITH orders AS (SELECT * FROM stg_orders),\n"
+        "     final AS (SELECT * FROM orders)\n"
+        "SELECT * FROM final"
+    )
+    parser = SqlParser()
+    result = parser.parse("marts/orders.sql", sql)
+
+    stg_edges = [e for e in result.edges if e.target_name == "stg_orders"]
+    # At least one edge from file_stem ("orders") to stg_orders with the new stamp
+    stem_sourced = [e for e in stg_edges if e.source_name == "orders" and e.source_kind == "table"]
+    assert stem_sourced, f"expected a table-kind outbound edge to stg_orders; got {stg_edges}"
+    assert (stem_sourced[0].metadata or {}).get("source_schema") == "marts"
+
+
+def test_create_view_wrap_stamps_source_kind_view():
+    """CREATE VIEW wrap emits edges with source_kind='view' (not 'table')."""
+    sql = (
+        'CREATE VIEW "analytics"."customer_stats" AS\n'
+        "WITH c AS (SELECT * FROM customers) SELECT * FROM c"
+    )
+    parser = SqlParser()
+    result = parser.parse("analytics/customer_stats.sql", sql)
+
+    cust_edges = [
+        e for e in result.edges
+        if e.target_name == "customers" and e.source_name == "customer_stats"
+    ]
+    assert cust_edges, "expected outbound edge to customers from the view"
+    assert cust_edges[0].source_kind == "view"
+    assert (cust_edges[0].metadata or {}).get("source_schema") == "analytics"
+
+
+def test_nested_cte_does_not_suppress_outer_scope_table():
+    """A CTE alias inside a subquery must not mask an outer-scope real table of the same name.
+
+    Regression guard: the CTE-skip uses a scope-local walk, so `foo` defined
+    inside a subquery's WITH does not suppress a sibling `FROM foo` in the
+    outer query.
+    """
+    sql = """
+    SELECT o.id, s.total
+    FROM foo o
+    JOIN (
+        WITH foo AS (SELECT id, sum(x) AS total FROM other GROUP BY id)
+        SELECT * FROM foo
+    ) s ON s.id = o.id
+    """
+    parser = SqlParser()
+    result = parser.parse("nested.sql", sql)
+
+    table_targets = {e.target_name for e in result.edges if e.target_kind == "table"}
+    # Outer `FROM foo` is a real table reference — it must NOT be suppressed
+    # even though a nested subquery has a CTE also named `foo`.
+    assert "foo" in table_targets
+    # `other` (inside the nested CTE) is also a real reference
+    assert "other" in table_targets
+
 
 def test_qualified_table_names():
     """Schema-qualified and catalog-qualified table names store metadata."""

--- a/tests/test_sql_parser.py
+++ b/tests/test_sql_parser.py
@@ -343,6 +343,51 @@ def test_cte_chain_edges():
     assert final_to_enriched[0].target_kind == "cte"
 
 
+def test_cte_alias_not_indexed_as_table_reference():
+    """CTE aliases referenced in FROM clauses must not create phantom `table` nodes or edges.
+
+    Regression for #119: dbt-compiled SQL with CTEs was emitting `query -> cte_alias (table)`
+    edges and creating `kind=table` nodes for CTE names like compute_booleans/joined.
+    """
+    sql = """
+    WITH orders AS (
+        SELECT * FROM stg_orders
+    ),
+    order_items_table AS (
+        SELECT * FROM order_items
+    ),
+    order_items_summary AS (
+        SELECT order_id, COUNT(*) FROM order_items_table GROUP BY 1
+    ),
+    compute_booleans AS (
+        SELECT orders.*, order_items_summary.order_id > 0 AS has_items
+        FROM orders LEFT JOIN order_items_summary ON orders.id = order_items_summary.order_id
+    )
+    SELECT * FROM compute_booleans
+    """
+    parser = SqlParser()
+    result = parser.parse("finance_orders.sql", sql)
+
+    cte_names = {"orders", "order_items_table", "order_items_summary", "compute_booleans"}
+
+    # No `kind=table` nodes for CTE aliases
+    table_nodes = {n.name for n in result.nodes if n.kind == "table"}
+    for alias in cte_names:
+        assert alias not in table_nodes, f"CTE alias {alias!r} must not be indexed as a table"
+
+    # No top-level references to CTE aliases from the file node
+    file_to_cte = [
+        e for e in result.edges
+        if e.source_name == "finance_orders" and e.target_name in cte_names
+    ]
+    assert not file_to_cte, f"File must not reference CTE aliases: {file_to_cte}"
+
+    # Real upstream tables ARE captured
+    table_targets = {e.target_name for e in result.edges if e.target_kind == "table"}
+    assert "stg_orders" in table_targets
+    assert "order_items" in table_targets
+
+
 def test_qualified_table_names():
     """Schema-qualified and catalog-qualified table names store metadata."""
     sql = """


### PR DESCRIPTION
Closes #119

## Summary
- SQL parser was treating CTE alias references as external table references, creating phantom `kind=table` nodes and polluting the graph with CTE names (compute_booleans, joined, order_items_summary, etc.)
- Collect CTE aliases per statement and skip them in `_extract_table_references`

## Test Plan
| Check | Status |
|-------|--------|
| New unit test: CTE alias does not leak as table node/edge | passing |
| Full test suite (564 tests) | passing |
| `uv run ruff check .` | passing |
| `uv run ty check` | passing |
| Bench: jaffle-mesh_lineage_01 F1 rises toward 1.0 | pending |