### PR TITLE
fix(122): trace excludes self via defines edge and CTE root

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -37,6 +37,27 @@ logger = logging.getLogger(__name__)
 _MAX_FILE_SIZE = 1 * 1024 * 1024  # 1 MB – skip snippets for oversized files
 _EXTEND_SUGGESTION_THRESHOLD = 0.8
 
+# Kinds that are query-local aliases — never a standalone entity a user would
+# trace or resolve. When `kind` is unspecified, these are excluded from trace
+# start-nodes and ranked last in `resolve_node`'s kind-relaxed fallback.
+_QUERY_LOCAL_KINDS = ("cte", "subquery")
+
+# Rank expression applied to a kind column to prefer real models over
+# query-local aliases. Lower rank wins in ``ORDER BY ... ASC``. Used by both
+# ``resolve_node`` and ``query_trace`` so the policy lives in one place. The
+# caller supplies the column reference (e.g. ``"n.kind"`` or ``"kind"``) so the
+# fragment composes with any query shape.
+def _kind_rank_sql(col: str) -> str:
+    return (
+        f"CASE {col} "
+        "WHEN 'table' THEN 0 "
+        "WHEN 'view' THEN 1 "
+        "WHEN 'query' THEN 2 "
+        "WHEN 'cte' THEN 99 "
+        "WHEN 'subquery' THEN 99 "
+        "ELSE 10 END"
+    )
+
 
 @lru_cache(maxsize=128)
 def _read_file_lines(path: str) -> tuple[str, ...] | None:
@@ -819,6 +840,10 @@ class GraphDB:
         The kind-relaxed fallback handles the common case where a SQL
         reference uses ``target_kind="table"`` but the actual node was
         indexed as ``"query"`` or ``"view"`` (e.g. sqlmesh/dbt models).
+        Within the fallback, non-matching kinds are ranked
+        ``table > view > query`` and query-local aliases (``cte``,
+        ``subquery``) are placed last so a real node always beats an alias
+        sharing the same name.
 
         Args:
             name: Unqualified entity name.
@@ -857,24 +882,17 @@ class GraphDB:
             return row[0]
 
         # 3. Kind-relaxed: match by name only, prefer real nodes (file_id IS NOT NULL).
-        # Secondary rank (when requested kind doesn't match): table > view > query
-        # > source > cte. CTEs are query-local aliases and must never win over a
-        # real node when a user looks up a name without a kind filter.
-        kind_rank_sql = (
-            "CASE n.kind "
-            "WHEN 'table' THEN 0 "
-            "WHEN 'view' THEN 1 "
-            "WHEN 'query' THEN 2 "
-            "WHEN 'source' THEN 3 "
-            "WHEN 'cte' THEN 99 "
-            "ELSE 10 END"
-        )
+        # Secondary rank (when requested kind doesn't match): table > view > query;
+        # CTEs and subqueries are query-local aliases and must never win over a
+        # real node when a user looks up a name without a kind filter. A final
+        # node_id tiebreaker keeps ordering deterministic across runs.
+        kind_rank = _kind_rank_sql("n.kind")
         if repo_id:
             row = self._execute_read(
                 "SELECT n.node_id FROM nodes n "
                 "JOIN files f ON n.file_id = f.file_id "
                 "WHERE n.name = ? AND f.repo_id = ?" + schema_clause
-                + f" ORDER BY (n.kind = ?) DESC, {kind_rank_sql} ASC LIMIT 1",
+                + f" ORDER BY (n.kind = ?) DESC, {kind_rank} ASC, n.node_id ASC LIMIT 1",
                 [name, repo_id] + schema_params + [kind],
             ).fetchone()
             if row:
@@ -884,7 +902,7 @@ class GraphDB:
         row = self._execute_read(
             "SELECT n.node_id FROM nodes n "
             "WHERE n.name = ? AND n.file_id IS NOT NULL" + schema_clause
-            + f" ORDER BY (n.kind = ?) DESC, {kind_rank_sql} ASC LIMIT 1",
+            + f" ORDER BY (n.kind = ?) DESC, {kind_rank} ASC, n.node_id ASC LIMIT 1",
             [name] + schema_params + [kind],
         ).fetchone()
         return row[0] if row else None
@@ -2535,6 +2553,14 @@ class GraphDB:
     ) -> dict:
         """Find all references to/from a named entity.
 
+        ``defines`` edges are never surfaced in either direction — they
+        represent CREATE-statement identity (the file-stem query node
+        paired with the table/view it declares), not a real reference.
+        Treating them as references would make a model appear to
+        "reference itself" via its own CREATE wrapper (issue #122).
+        Callers that need to locate the defining file should query the
+        edges table directly.
+
         Args:
             name: Entity name to look up.
             kind: Optional node kind filter.
@@ -2801,6 +2827,41 @@ class GraphDB:
 
         return {"matches": matches, "total_count": total}
 
+    def _find_trace_start_nodes(self, name: str, kind: str | None) -> list:
+        """Resolve trace start nodes for ``name``, ordered by kind preference.
+
+        When ``kind`` is specified, only nodes of that kind match. When it
+        is unspecified, query-local aliases (``cte``, ``subquery``) are
+        excluded so a real model always becomes the reported root. If the
+        filtered query returns nothing, the call falls back to matching
+        aliases so a user tracing a CTE-only name still gets a result.
+        Rows are ordered by ``_kind_rank_sql`` then ``node_id`` for
+        determinism.
+
+        Returns ``(node_id, name, kind)`` rows in preference order.
+        """
+        rank = _kind_rank_sql("kind")
+        base_sql = (
+            f"SELECT node_id, name, kind FROM nodes WHERE name = ? {{extra}} "
+            f"ORDER BY {rank} ASC, node_id ASC"
+        )
+        if kind:
+            return self._execute_read(
+                base_sql.format(extra="AND kind = ?"), [name, kind]
+            ).fetchall()
+
+        placeholders = ",".join("?" * len(_QUERY_LOCAL_KINDS))
+        rows = self._execute_read(
+            base_sql.format(extra=f"AND kind NOT IN ({placeholders})"),
+            [name, *_QUERY_LOCAL_KINDS],
+        ).fetchall()
+        if rows:
+            return rows
+
+        # Fallback: name matches only query-local aliases. Return them so the
+        # user still gets a trace from what exists rather than a silent empty.
+        return self._execute_read(base_sql.format(extra=""), [name]).fetchall()
+
     def query_trace(
         self,
         name: str,
@@ -2813,6 +2874,15 @@ class GraphDB:
         exclude_edges: set[tuple[str, str]] | None = None,
     ) -> dict:
         """Trace multi-hop dependency chains via DuckPGQ or recursive CTE.
+
+        When ``kind`` is unspecified, query-local aliases (``cte``,
+        ``subquery``) are excluded from start-node candidates so a
+        within-query alias never becomes the reported root. If the name
+        only resolves to such aliases (no real table/view/query exists),
+        the call falls back to the alias match so the user still gets a
+        trace. ``defines`` edges are never followed — they represent
+        CREATE identity, not dataflow, and would otherwise pull a
+        model's own file-stem query back into its trace (issue #122).
 
         Args:
             name: Starting entity name.
@@ -2839,29 +2909,7 @@ class GraphDB:
             and ``"upstream"`` keys instead of a single ``"paths"``.
         """
         max_depth = max(min(max_depth, 10), 1)
-        # Find starting node(s). When kind is unspecified, drop CTE matches so a
-        # query-local alias never wins over a real model of the same name, and
-        # rank remaining kinds table > view > query > source so the reported
-        # root matches what a user would expect to trace.
-        where = ["name = ?"]
-        params: list = [name]
-        if kind:
-            where.append("kind = ?")
-            params.append(kind)
-        else:
-            where.append("kind <> 'cte'")
-
-        start_nodes = self._execute_read(
-            f"SELECT node_id, name, kind FROM nodes WHERE {' AND '.join(where)} "
-            "ORDER BY CASE kind "
-            "WHEN 'table' THEN 0 "
-            "WHEN 'view' THEN 1 "
-            "WHEN 'query' THEN 2 "
-            "WHEN 'source' THEN 3 "
-            "ELSE 10 END ASC",
-            params,
-        ).fetchall()
-
+        start_nodes = self._find_trace_start_nodes(name, kind)
         if not start_nodes:
             return {"root": None, "paths": [], "depth_summary": {}, "repos_affected": []}
 

--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -856,13 +856,25 @@ class GraphDB:
         if row:
             return row[0]
 
-        # 3. Kind-relaxed: match by name only, prefer real nodes (file_id IS NOT NULL)
+        # 3. Kind-relaxed: match by name only, prefer real nodes (file_id IS NOT NULL).
+        # Secondary rank (when requested kind doesn't match): table > view > query
+        # > source > cte. CTEs are query-local aliases and must never win over a
+        # real node when a user looks up a name without a kind filter.
+        kind_rank_sql = (
+            "CASE n.kind "
+            "WHEN 'table' THEN 0 "
+            "WHEN 'view' THEN 1 "
+            "WHEN 'query' THEN 2 "
+            "WHEN 'source' THEN 3 "
+            "WHEN 'cte' THEN 99 "
+            "ELSE 10 END"
+        )
         if repo_id:
             row = self._execute_read(
                 "SELECT n.node_id FROM nodes n "
                 "JOIN files f ON n.file_id = f.file_id "
                 "WHERE n.name = ? AND f.repo_id = ?" + schema_clause
-                + " ORDER BY (n.kind = ?) DESC LIMIT 1",
+                + f" ORDER BY (n.kind = ?) DESC, {kind_rank_sql} ASC LIMIT 1",
                 [name, repo_id] + schema_params + [kind],
             ).fetchone()
             if row:
@@ -872,7 +884,7 @@ class GraphDB:
         row = self._execute_read(
             "SELECT n.node_id FROM nodes n "
             "WHERE n.name = ? AND n.file_id IS NOT NULL" + schema_clause
-            + " ORDER BY (n.kind = ?) DESC LIMIT 1",
+            + f" ORDER BY (n.kind = ?) DESC, {kind_rank_sql} ASC LIMIT 1",
             [name] + schema_params + [kind],
         ).fetchone()
         return row[0] if row else None
@@ -2575,6 +2587,7 @@ class GraphDB:
                 f"LEFT JOIN files f2 ON n2.file_id = f2.file_id "
                 f"LEFT JOIN repos r2 ON f2.repo_id = r2.repo_id "
                 f"WHERE e.target_id IN ({placeholders}) "
+                f"AND e.relationship <> 'defines' "
                 f"LIMIT ? OFFSET ?"
             )
             for r in self._execute_read(inbound_sql, node_ids + [limit, offset]).fetchall():
@@ -2603,6 +2616,7 @@ class GraphDB:
                 f"LEFT JOIN files f2 ON n2.file_id = f2.file_id "
                 f"LEFT JOIN repos r2 ON f2.repo_id = r2.repo_id "
                 f"WHERE e.source_id IN ({placeholders}) "
+                f"AND e.relationship <> 'defines' "
                 f"LIMIT ? OFFSET ?"
             )
             for r in self._execute_read(outbound_sql, node_ids + [limit, offset]).fetchall():
@@ -2825,15 +2839,26 @@ class GraphDB:
             and ``"upstream"`` keys instead of a single ``"paths"``.
         """
         max_depth = max(min(max_depth, 10), 1)
-        # Find starting node(s)
+        # Find starting node(s). When kind is unspecified, drop CTE matches so a
+        # query-local alias never wins over a real model of the same name, and
+        # rank remaining kinds table > view > query > source so the reported
+        # root matches what a user would expect to trace.
         where = ["name = ?"]
         params: list = [name]
         if kind:
             where.append("kind = ?")
             params.append(kind)
+        else:
+            where.append("kind <> 'cte'")
 
         start_nodes = self._execute_read(
-            f"SELECT node_id, name, kind FROM nodes WHERE {' AND '.join(where)}",
+            f"SELECT node_id, name, kind FROM nodes WHERE {' AND '.join(where)} "
+            "ORDER BY CASE kind "
+            "WHEN 'table' THEN 0 "
+            "WHEN 'view' THEN 1 "
+            "WHEN 'query' THEN 2 "
+            "WHEN 'source' THEN 3 "
+            "ELSE 10 END ASC",
             params,
         ).fetchall()
 
@@ -2950,6 +2975,13 @@ class GraphDB:
                 pairs_sql = ", ".join(f"({s}, {t})" for s, t in excluded_id_pairs)
                 exclude_clause = f"AND (e.source_id, e.target_id) NOT IN (VALUES {pairs_sql})"
 
+        # defines edges represent CREATE-statement identity (file_stem query
+        # node -> table/view it defines), not dataflow. Excluding them from
+        # traversal prevents a model from appearing in its own trace when a
+        # start node shares a name with a node that was defined by that
+        # model's file (see issue #122).
+        defines_clause = "AND e.relationship <> 'defines'"
+
         recursive_sql = f"""
         WITH RECURSIVE trace AS (
             SELECT
@@ -2960,6 +2992,7 @@ class GraphDB:
                 ARRAY[e.{source_col}] as path
             FROM edges e
             WHERE e.{source_col} = ?
+            {defines_clause}
             {exclude_clause}
 
             UNION ALL
@@ -2974,6 +3007,7 @@ class GraphDB:
             JOIN trace t ON e.{source_col} = t.node_id
             WHERE t.depth < ?
             AND NOT array_contains(t.path, e.{target_col})
+            {defines_clause}
             {exclude_clause}
         )
         SELECT DISTINCT

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1523,3 +1523,124 @@ def test_trace_max_depth_boundary():
     db.close()
 
 
+def _build_cte_alias_graph():
+    """Simulate a dbt-compiled model whose file stem is also a CTE alias.
+
+    Mirrors jaffle-mesh finance/orders.sql where ``orders`` exists as:
+      - query (file stem, the CREATE wrapper)
+      - table (the CREATEd target)
+      - cte (the first CTE in the WITH clause that reads from stg_orders)
+
+    Edges mirror the SQL parser's convention
+    (``source_name = file_stem``, ``target_name = referenced_table``):
+
+      orders (query)      -[defines]->        orders (table)       # CREATE wrap
+      orders (query)      -[references]->     stg_orders (table)   # orders.sql FROM stg_orders
+      orders (cte)        -[cte_references]-> stg_orders (table)
+      order_items (query) -[references]->     orders (table)       # a separate model reads orders
+    """
+    db = GraphDB()
+    repo_id = db.upsert_repo("cte-alias-repo", "/tmp/cte-alias")
+    orders_file = db.insert_file(repo_id, "orders.sql", "sql", "cte-alias-123")
+    items_file = db.insert_file(repo_id, "order_items.sql", "sql", "items-456")
+
+    orders_query = db.insert_node(orders_file, "query", "orders", "sql")
+    orders_table = db.insert_node(orders_file, "table", "orders", "sql")
+    orders_cte = db.insert_node(orders_file, "cte", "orders", "sql")
+    stg_orders = db.insert_node(orders_file, "table", "stg_orders", "sql")
+    items_query = db.insert_node(items_file, "query", "order_items", "sql")
+
+    db.insert_edge(orders_query, orders_table, "defines", "CREATE statement")
+    db.insert_edge(orders_query, stg_orders, "references")
+    db.insert_edge(orders_cte, stg_orders, "cte_references")
+    db.insert_edge(items_query, orders_table, "references")
+    return db
+
+
+def test_trace_prefers_table_root_over_cte():
+    """Issue #122: query_trace without kind picks table as root, not cte."""
+    db = _build_cte_alias_graph()
+
+    result = db.query_trace("orders", direction="downstream", max_depth=3)
+
+    _assert_trace_structure(result)
+    assert result["root"] == {"name": "orders", "kind": "table"}
+    db.close()
+
+
+def test_trace_excludes_self_via_defines_edge():
+    """Issue #122: orders (model) does not appear in its own downstream trace."""
+    db = _build_cte_alias_graph()
+
+    result = db.query_trace("orders", direction="downstream", max_depth=5)
+
+    names = {p["name"] for p in result["paths"]}
+    # orders itself must not appear — the defines edge is identity, not dataflow,
+    # and a query-local CTE alias must not pull the CREATE target back in.
+    assert "orders" not in names
+    db.close()
+
+
+def test_trace_upstream_excludes_self_via_defines_edge():
+    """Issue #122: upstream trace also filters the defines edge."""
+    db = _build_cte_alias_graph()
+
+    result = db.query_trace("orders", direction="upstream", max_depth=5)
+
+    names = {p["name"] for p in result["paths"]}
+    assert "orders" not in names
+    db.close()
+
+
+def test_references_excludes_defines_edge():
+    """Issue #122: query_references skips defines edges in both directions."""
+    db = _build_cte_alias_graph()
+
+    result = db.query_references("orders", kind="table", include_snippets=False)
+
+    inbound_rels = {e["relationship"] for e in result["inbound"]}
+    outbound_rels = {e["relationship"] for e in result["outbound"]}
+    assert "defines" not in inbound_rels
+    assert "defines" not in outbound_rels
+    # Non-defines inbound references still surface (order_items model reads orders)
+    inbound_names = {e["name"] for e in result["inbound"]}
+    assert "order_items" in inbound_names
+    db.close()
+
+
+def test_trace_explicit_cte_kind_still_works():
+    """Asking for kind='cte' explicitly traces from the CTE node."""
+    db = _build_cte_alias_graph()
+
+    result = db.query_trace("orders", kind="cte", direction="downstream", max_depth=3)
+
+    _assert_trace_structure(result)
+    assert result["root"] == {"name": "orders", "kind": "cte"}
+    # The CTE references stg_orders via cte_references — still surfaces.
+    names = {p["name"] for p in result["paths"]}
+    assert "stg_orders" in names
+    db.close()
+
+
+def test_resolve_node_fallback_prefers_table_over_cte():
+    """Issue #122: kind-relaxed fallback ranks table > view > query > cte."""
+    db = GraphDB()
+    repo_id = db.upsert_repo("rank-repo", "/tmp/rank")
+    file_id = db.insert_file(repo_id, "orders.sql", "sql", "rank-123")
+
+    # Insert cte first to prove ordering is not insertion-order dependent.
+    db.insert_node(file_id, "cte", "orders", "sql")
+    query_id = db.insert_node(file_id, "query", "orders", "sql")
+    view_id = db.insert_node(file_id, "view", "orders", "sql")
+    table_id = db.insert_node(file_id, "table", "orders", "sql")
+
+    # Requested kind 'source' doesn't exist here, forcing the kind-relaxed
+    # secondary rank to decide: table > view > query > cte.
+    assert db.resolve_node("orders", "source", repo_id) == table_id
+    # Cross-repo fallback path (no repo_id) follows the same ordering.
+    assert db.resolve_node("orders", "source") == table_id
+    # Requested kind takes precedence over the secondary rank.
+    assert db.resolve_node("orders", "view", repo_id) == view_id
+    assert db.resolve_node("orders", "query", repo_id) == query_id
+    db.close()
+

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1558,18 +1558,28 @@ def _build_cte_alias_graph():
 
 
 def test_trace_prefers_table_root_over_cte():
-    """Issue #122: query_trace without kind picks table as root, not cte."""
+    """Issue #122: query_trace without kind picks table root and produces clean paths.
+
+    Covers the full BDD acceptance criteria from the issue in a single test:
+    given ``orders`` exists as table/query/cte, the reported root is the table
+    and ``orders`` never appears in its own downstream paths — while the
+    legitimate downstream target ``stg_orders`` still surfaces so the filter
+    is proven surgical, not wholesale.
+    """
     db = _build_cte_alias_graph()
 
     result = db.query_trace("orders", direction="downstream", max_depth=3)
 
     _assert_trace_structure(result)
     assert result["root"] == {"name": "orders", "kind": "table"}
+    names = {p["name"] for p in result["paths"]}
+    assert "orders" not in names
+    assert "stg_orders" in names
     db.close()
 
 
 def test_trace_excludes_self_via_defines_edge():
-    """Issue #122: orders (model) does not appear in its own downstream trace."""
+    """Issue #122: orders does not appear in its own downstream trace; real refs do."""
     db = _build_cte_alias_graph()
 
     result = db.query_trace("orders", direction="downstream", max_depth=5)
@@ -1578,17 +1588,42 @@ def test_trace_excludes_self_via_defines_edge():
     # orders itself must not appear — the defines edge is identity, not dataflow,
     # and a query-local CTE alias must not pull the CREATE target back in.
     assert "orders" not in names
+    # ...and a legitimate downstream target still surfaces — proves the filter
+    # is surgical rather than wholesale.
+    assert "stg_orders" in names
+    # No path should carry the 'defines' relationship after filtering.
+    assert all(p["relationship"] != "defines" for p in result["paths"])
     db.close()
 
 
 def test_trace_upstream_excludes_self_via_defines_edge():
-    """Issue #122: upstream trace also filters the defines edge."""
+    """Issue #122: upstream trace also filters the defines edge without collateral damage."""
     db = _build_cte_alias_graph()
 
     result = db.query_trace("orders", direction="upstream", max_depth=5)
 
     names = {p["name"] for p in result["paths"]}
     assert "orders" not in names
+    # The order_items model reads orders via a real references edge — that must
+    # still surface when tracing upstream from orders (table).
+    assert "order_items" in names
+    assert all(p["relationship"] != "defines" for p in result["paths"])
+    db.close()
+
+
+def test_trace_both_direction_excludes_self_via_defines_edge():
+    """direction='both' splits paths and applies the defines filter to each side."""
+    db = _build_cte_alias_graph()
+
+    result = db.query_trace("orders", direction="both", max_depth=3)
+
+    assert result["root"] == {"name": "orders", "kind": "table"}
+    downstream_names = {p["name"] for p in result["downstream"]}
+    upstream_names = {p["name"] for p in result["upstream"]}
+    assert "orders" not in downstream_names
+    assert "orders" not in upstream_names
+    assert "stg_orders" in downstream_names
+    assert "order_items" in upstream_names
     db.close()
 
 
@@ -1608,6 +1643,31 @@ def test_references_excludes_defines_edge():
     db.close()
 
 
+def test_references_outbound_filters_defines_not_real_refs():
+    """query_references outbound filter drops defines but keeps real references.
+
+    Resolves to the ``orders (query)`` node — which has both a ``defines`` edge
+    to ``orders (table)`` and a ``references`` edge to ``stg_orders``. Without
+    this coverage the outbound filter could be silently removed and
+    ``test_references_excludes_defines_edge`` would still pass vacuously
+    (``orders (table)`` has no outbound edges in the fixture).
+    """
+    db = _build_cte_alias_graph()
+
+    result = db.query_references("orders", kind="query", include_snippets=False)
+
+    outbound = result["outbound"]
+    out_names = {e["name"] for e in outbound}
+    out_rels = {e["relationship"] for e in outbound}
+    # Real references survive
+    assert "stg_orders" in out_names
+    assert "references" in out_rels
+    # The defines target (the CREATE'd orders table) must not leak through
+    assert "orders" not in out_names
+    assert "defines" not in out_rels
+    db.close()
+
+
 def test_trace_explicit_cte_kind_still_works():
     """Asking for kind='cte' explicitly traces from the CTE node."""
     db = _build_cte_alias_graph()
@@ -1622,25 +1682,101 @@ def test_trace_explicit_cte_kind_still_works():
     db.close()
 
 
+def test_trace_falls_back_to_cte_when_no_real_node():
+    """When kind is unspecified and only a CTE matches the name, fall back to it.
+
+    Without the fallback, ``query_trace("my_cte")`` would return an empty root
+    indistinguishable from "not indexed" — callers would have no signal that
+    the name actually exists in the graph.
+    """
+    db = GraphDB()
+    repo_id = db.upsert_repo("cte-only-repo", "/tmp/cte-only")
+    file_id = db.insert_file(repo_id, "pipeline.sql", "sql", "cte-only-123")
+
+    # No table/view/query named 'scratch' — only the CTE alias exists.
+    db.insert_node(file_id, "cte", "scratch", "sql")
+    pipeline = db.insert_node(file_id, "query", "pipeline", "sql")
+    # No edges are needed for this assertion; root resolution is what matters.
+
+    result = db.query_trace("scratch", direction="downstream")
+
+    assert result["root"] == {"name": "scratch", "kind": "cte"}
+    # Not strictly needed but confirms the structure is well-formed
+    _assert_trace_structure(result)
+    _ = pipeline  # silence unused
+    db.close()
+
+
+def test_trace_prefers_table_root_over_subquery():
+    """subquery aliases behave like CTEs and must never win as a trace root."""
+    db = GraphDB()
+    repo_id = db.upsert_repo("subq-repo", "/tmp/subq")
+    file_id = db.insert_file(repo_id, "orders.sql", "sql", "subq-123")
+
+    # Insert the subquery first so ordering depends on kind rank, not insertion.
+    db.insert_node(file_id, "subquery", "orders", "sql")
+    table_id = db.insert_node(file_id, "table", "orders", "sql")
+    stg = db.insert_node(file_id, "table", "stg_orders", "sql")
+    # Table points downstream to stg so the trace has something to find from root.
+    db.insert_edge(table_id, stg, "references")
+
+    result = db.query_trace("orders", direction="downstream", max_depth=3)
+
+    assert result["root"] == {"name": "orders", "kind": "table"}
+    names = {p["name"] for p in result["paths"]}
+    assert "stg_orders" in names
+    db.close()
+
+
 def test_resolve_node_fallback_prefers_table_over_cte():
-    """Issue #122: kind-relaxed fallback ranks table > view > query > cte."""
+    """Issue #122: kind-relaxed fallback ranks table > view > query; aliases last."""
     db = GraphDB()
     repo_id = db.upsert_repo("rank-repo", "/tmp/rank")
     file_id = db.insert_file(repo_id, "orders.sql", "sql", "rank-123")
 
-    # Insert cte first to prove ordering is not insertion-order dependent.
+    # Insert aliases first to prove ordering is not insertion-order dependent.
     db.insert_node(file_id, "cte", "orders", "sql")
+    db.insert_node(file_id, "subquery", "orders", "sql")
     query_id = db.insert_node(file_id, "query", "orders", "sql")
     view_id = db.insert_node(file_id, "view", "orders", "sql")
     table_id = db.insert_node(file_id, "table", "orders", "sql")
 
     # Requested kind 'source' doesn't exist here, forcing the kind-relaxed
-    # secondary rank to decide: table > view > query > cte.
+    # secondary rank to decide: table > view > query; cte and subquery last.
     assert db.resolve_node("orders", "source", repo_id) == table_id
     # Cross-repo fallback path (no repo_id) follows the same ordering.
     assert db.resolve_node("orders", "source") == table_id
     # Requested kind takes precedence over the secondary rank.
     assert db.resolve_node("orders", "view", repo_id) == view_id
     assert db.resolve_node("orders", "query", repo_id) == query_id
+    db.close()
+
+
+def test_resolve_node_fallback_respects_schema_filter():
+    """Kind-relaxed fallback honors the schema qualifier in both branches."""
+    db = GraphDB()
+    repo_id = db.upsert_repo("schema-rank-repo", "/tmp/schema-rank")
+    file_id = db.insert_file(repo_id, "orders.sql", "sql", "schema-rank-123")
+
+    # Two real nodes named 'orders' in distinct schemas plus a same-name CTE
+    # with no schema. The fallback must prefer the schema-qualified table.
+    staging_table = db.insert_node(
+        file_id, "table", "orders", "sql", schema="staging"
+    )
+    prod_table = db.insert_node(
+        file_id, "table", "orders", "sql", schema="production"
+    )
+    db.insert_node(file_id, "cte", "orders", "sql")
+
+    # Same-repo schema-qualified fallback
+    assert (
+        db.resolve_node("orders", "source", repo_id, schema="staging")
+        == staging_table
+    )
+    # Cross-repo schema-qualified fallback
+    assert (
+        db.resolve_node("orders", "source", schema="production")
+        == prod_table
+    )
     db.close()
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -304,7 +304,7 @@ def test_trace_dependencies_downstream(tmp_path):
 
 
 def test_trace_dependencies_upstream(tmp_path):
-    """trace_dependencies follows upstream references."""
+    """trace_dependencies follows upstream references (non-defines edges)."""
     repo_dir = tmp_path / "trace_up_repo"
     repo_dir.mkdir()
     (repo_dir / "orders.sql").write_text("CREATE TABLE orders (id INT, amount DECIMAL)")
@@ -320,10 +320,11 @@ def test_trace_dependencies_upstream(tmp_path):
     indexer = _get_indexer()
     indexer.reindex_repo("test", str(repo_dir))
 
-    # Edge: summary(query) -[defines]-> order_summary(view)
-    # Upstream from order_summary finds the defining query node.
+    # Upstream from orders (table) traverses the real references edge:
+    # summary(query) -[references]-> orders(table). The defines edge from
+    # summary(query) -> order_summary(view) is intentionally excluded per #122.
     result = asyncio.run(
-        trace_dependencies(TraceDependenciesInput(name="order_summary", direction="upstream", max_depth=3))
+        trace_dependencies(TraceDependenciesInput(name="orders", direction="upstream", max_depth=3))
     )
     assert result["root"] is not None
     assert len(result["paths"]) >= 1

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -304,7 +304,15 @@ def test_trace_dependencies_downstream(tmp_path):
 
 
 def test_trace_dependencies_upstream(tmp_path):
-    """trace_dependencies follows upstream references (non-defines edges)."""
+    """trace_dependencies follows upstream references and skips defines edges.
+
+    Exercises two MCP-integration invariants in one repo:
+      * A regular `references` edge (summary(query) -> orders(table)) surfaces
+        upstream from `orders`.
+      * The `defines` edge (summary(query) -> order_summary(view)) does NOT
+        surface upstream from `order_summary`, directly guarding the fix for
+        issue #122 at the MCP tool layer.
+    """
     repo_dir = tmp_path / "trace_up_repo"
     repo_dir.mkdir()
     (repo_dir / "orders.sql").write_text("CREATE TABLE orders (id INT, amount DECIMAL)")
@@ -321,8 +329,7 @@ def test_trace_dependencies_upstream(tmp_path):
     indexer.reindex_repo("test", str(repo_dir))
 
     # Upstream from orders (table) traverses the real references edge:
-    # summary(query) -[references]-> orders(table). The defines edge from
-    # summary(query) -> order_summary(view) is intentionally excluded per #122.
+    # summary(query) -[references]-> orders(table).
     result = asyncio.run(
         trace_dependencies(TraceDependenciesInput(name="orders", direction="upstream", max_depth=3))
     )
@@ -330,6 +337,19 @@ def test_trace_dependencies_upstream(tmp_path):
     assert len(result["paths"]) >= 1
     upstream_names = {p["name"] for p in result["paths"]}
     assert "summary" in upstream_names
+    assert all(p["relationship"] != "defines" for p in result["paths"])
+
+    # Upstream from order_summary (view) would previously surface summary(query)
+    # via the defines edge. With the #122 fix that edge is filtered, so no
+    # path should appear via that relationship.
+    result_view = asyncio.run(
+        trace_dependencies(
+            TraceDependenciesInput(name="order_summary", direction="upstream", max_depth=3)
+        )
+    )
+    assert all(p["relationship"] != "defines" for p in result_view["paths"])
+    view_upstream_names = {p["name"] for p in result_view["paths"]}
+    assert "summary" not in view_upstream_names
 
 
 def test_trace_dependencies_not_found(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1436,7 +1436,7 @@ wheels = [
 
 [[package]]
 name = "sqlprism"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #122

## Summary
- `query_trace` no longer roots on a CTE-kind node when `kind` is unspecified — CTE matches are dropped as start nodes and remaining candidates are ordered `table > view > query > source`.
- `_trace_cte` and `query_references` exclude `relationship = 'defines'` edges. `defines` represents CREATE identity (query -> table/view it defines), not dataflow, so it no longer pulls the CREATE target into a model's own trace.
- `resolve_node` kind-relaxed fallback ranks `table > view > query > source > cte`, so a query-local CTE alias never beats a real node when the caller asks for a name without a precise kind.
- Rewrote `test_trace_dependencies_upstream` in `test_mcp_tools.py`, which previously asserted the buggy behavior (following a `defines` edge upstream to surface the defining query).

## Test Plan
| Scenario | Status |
| --- | --- |
| `query trace orders` without kind roots on `orders (table)`, not `orders (cte)` | done |
| `orders` does not appear in its own downstream trace when a CTE alias shares the name | done |
| Upstream trace also skips the `defines` edge | done |
| `query_references("orders", kind="table")` excludes `defines` in both directions while retaining real `references` | done |
| `kind='cte'` explicitly still works and traces from the CTE node | done |
| `resolve_node` kind-relaxed fallback prefers `table > view > query > source > cte` | done |
| Full test suite (`pytest tests/ -q`) | done — 595 passed, 1 xfailed |
| Lint / type-check (`ruff check .` + `ty check`) | done — both clean |
