### PR TITLE
fix-124-sqlmesh-column-defs-resolution

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -825,6 +825,7 @@ class GraphDB:
         kind: str,
         repo_id: int | None = None,
         schema: str | None = None,
+        same_repo_only: bool = False,
     ) -> int | None:
         """Find a node by name and kind.
 
@@ -849,9 +850,13 @@ class GraphDB:
             name: Unqualified entity name.
             kind: Node kind to match.
             repo_id: Prefer nodes from this repo. Falls back to cross-repo
-                search if not found.
+                search if not found (unless ``same_repo_only`` is set).
             schema: Optional schema qualifier. When provided, only nodes
                 with a matching ``schema`` column are returned.
+            same_repo_only: Skip cross-repo steps 2 and 4. Callers that
+                persist data against the resolved node (e.g. column-def
+                inserts) must use this to avoid attaching rows to a
+                different repo's node.
 
         Returns:
             The ``node_id`` if found, otherwise ``None``.
@@ -873,13 +878,14 @@ class GraphDB:
             if row:
                 return row[0]
 
-        # 2. Exact kind match cross-repo
-        row = self._execute_read(
-            "SELECT n.node_id FROM nodes n WHERE n.name = ? AND n.kind = ?" + schema_clause + " LIMIT 1",
-            [name, kind] + schema_params,
-        ).fetchone()
-        if row:
-            return row[0]
+        if not same_repo_only:
+            # 2. Exact kind match cross-repo
+            row = self._execute_read(
+                "SELECT n.node_id FROM nodes n WHERE n.name = ? AND n.kind = ?" + schema_clause + " LIMIT 1",
+                [name, kind] + schema_params,
+            ).fetchone()
+            if row:
+                return row[0]
 
         # 3. Kind-relaxed: match by name only, prefer real nodes (file_id IS NOT NULL).
         # Secondary rank (when requested kind doesn't match): table > view > query;
@@ -897,6 +903,9 @@ class GraphDB:
             ).fetchone()
             if row:
                 return row[0]
+
+        if same_repo_only:
+            return None
 
         # 4. Kind-relaxed cross-repo
         row = self._execute_read(

--- a/src/sqlprism/core/indexer.py
+++ b/src/sqlprism/core/indexer.py
@@ -974,21 +974,33 @@ class Indexer:
 
         # ── Batch insert column definitions ──
         if result.columns:
+            # sqlmesh emits fully-qualified quoted names like
+            # '"platform"."stg_orders"', but the parser stores the bare base
+            # name. Normalise so both forms resolve to the same node.
+            # ``query`` is included because rendered sqlmesh models are bare
+            # ``SELECT`` statements — the file-level node ends up as kind=query.
+            allowed_kinds = ("table", "view", "source", "query")
             col_rows = []
             for col_def in result.columns:
-                # Try to resolve node_id from local map (table/view only, matching kind)
+                raw_name = col_def.node_name
+                base_name = raw_name.replace('"."', ".").strip('"').rsplit(".", 1)[-1]
+                candidates = [base_name] if base_name == raw_name else [base_name, raw_name]
                 node_id = None
-                for key, nid in node_id_map.items():
-                    if key[0] == col_def.node_name and key[1] in ("table", "view", "source"):
-                        node_id = nid
+                for name in candidates:
+                    for key, nid in node_id_map.items():
+                        if key[0] == name and key[1] in allowed_kinds:
+                            node_id = nid
+                            break
+                    if node_id:
                         break
-                # Fall back to graph resolution
                 if not node_id:
-                    node_id = self.graph.resolve_node(col_def.node_name, "table", repo_id)
-                if not node_id:
-                    node_id = self.graph.resolve_node(col_def.node_name, "view", repo_id)
-                if not node_id:
-                    node_id = self.graph.resolve_node(col_def.node_name, "source", repo_id)
+                    for name in candidates:
+                        for kind in allowed_kinds:
+                            node_id = self.graph.resolve_node(name, kind, repo_id)
+                            if node_id:
+                                break
+                        if node_id:
+                            break
                 if not node_id:
                     logger.warning(
                         "Column def skipped: cannot resolve node '%s' for column '%s'",

--- a/src/sqlprism/core/indexer.py
+++ b/src/sqlprism/core/indexer.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from sqlprism.core.conventions import ConventionEngine, TagAssignment
 from sqlprism.core.graph import GraphDB
+from sqlprism.core.naming import parse_qualified_name
 from sqlprism.languages import SQL_EXTENSIONS, is_sql_file
 from sqlprism.languages.sql import SqlParser
 from sqlprism.types import ParseResult
@@ -911,16 +912,37 @@ class Indexer:
         if result.column_usage:
             cu_rows = []
             for cu in result.column_usage:
-                # Try schema-aware lookup first, then fall back to schema=None
-                cu_node_id = node_id_map.get((cu.node_name, cu.node_kind, None))
-                if not cu_node_id:
-                    # Try all schemas for this (name, kind)
+                # Normalise fully-qualified names so quoted sqlmesh-style
+                # node_names resolve to their parser-stored base-name node.
+                cu_base, cu_schema = parse_qualified_name(cu.node_name)
+                cu_candidates = [cu_base] if cu_base == cu.node_name else [cu_base, cu.node_name]
+                cu_node_id = None
+                for cand in cu_candidates:
+                    # Schema-aware match first, then schema-agnostic.
+                    if cu_schema:
+                        cu_node_id = node_id_map.get((cand, cu.node_kind, cu_schema))
+                        if cu_node_id:
+                            break
+                    cu_node_id = node_id_map.get((cand, cu.node_kind, None))
+                    if cu_node_id:
+                        break
                     for key, nid in node_id_map.items():
-                        if key[0] == cu.node_name and key[1] == cu.node_kind:
+                        if key[0] == cand and key[1] == cu.node_kind:
                             cu_node_id = nid
                             break
+                    if cu_node_id:
+                        break
                 if not cu_node_id:
-                    cu_node_id = self.graph.resolve_node(cu.node_name, cu.node_kind, repo_id)
+                    for cand in cu_candidates:
+                        if cu_schema:
+                            cu_node_id = self.graph.resolve_node(
+                                cand, cu.node_kind, repo_id, schema=cu_schema,
+                            )
+                            if cu_node_id:
+                                break
+                        cu_node_id = self.graph.resolve_node(cand, cu.node_kind, repo_id)
+                        if cu_node_id:
+                            break
                 if cu_node_id:
                     cu_rows.append(
                         (
@@ -974,33 +996,11 @@ class Indexer:
 
         # ── Batch insert column definitions ──
         if result.columns:
-            # sqlmesh emits fully-qualified quoted names like
-            # '"platform"."stg_orders"', but the parser stores the bare base
-            # name. Normalise so both forms resolve to the same node.
-            # ``query`` is included because rendered sqlmesh models are bare
-            # ``SELECT`` statements — the file-level node ends up as kind=query.
-            allowed_kinds = ("table", "view", "source", "query")
             col_rows = []
             for col_def in result.columns:
-                raw_name = col_def.node_name
-                base_name = raw_name.replace('"."', ".").strip('"').rsplit(".", 1)[-1]
-                candidates = [base_name] if base_name == raw_name else [base_name, raw_name]
-                node_id = None
-                for name in candidates:
-                    for key, nid in node_id_map.items():
-                        if key[0] == name and key[1] in allowed_kinds:
-                            node_id = nid
-                            break
-                    if node_id:
-                        break
-                if not node_id:
-                    for name in candidates:
-                        for kind in allowed_kinds:
-                            node_id = self.graph.resolve_node(name, kind, repo_id)
-                            if node_id:
-                                break
-                        if node_id:
-                            break
+                node_id = self._resolve_column_def_node(
+                    col_def.node_name, node_id_map, repo_id,
+                )
                 if not node_id:
                     logger.warning(
                         "Column def skipped: cannot resolve node '%s' for column '%s'",
@@ -1021,6 +1021,56 @@ class Indexer:
             if col_rows:
                 self.graph.insert_columns_batch(col_rows)
             stats["columns_added"] += len(col_rows)
+
+    # Kinds a ``ColumnDefResult`` may legitimately target. ``query`` is
+    # included because rendered sqlmesh models are bare ``SELECT``s — the
+    # file-level node ends up as kind=query.
+    _COLUMN_DEF_KINDS = ("table", "view", "source", "query")
+
+    def _resolve_column_def_node(
+        self,
+        raw_name: str,
+        local_map: dict[tuple[str, str, str | None], int],
+        repo_id: int,
+    ) -> int | None:
+        """Resolve a ``ColumnDefResult`` target node to a node_id.
+
+        Parses fully-qualified forms like ``"platform"."stg_orders"`` into
+        a base name + schema and uses the schema as an exact-match filter
+        before falling back to schema-agnostic lookup. Restricted to the
+        current repo — a cross-repo match would silently attach column
+        rows to another repo's node.
+        """
+        base, schema = parse_qualified_name(raw_name)
+        candidates = [base] if base == raw_name else [base, raw_name]
+
+        # Local map lookup — prefer schema-aware match, then schema-agnostic.
+        for name in candidates:
+            for probe_schema in (schema, None) if schema else (None,):
+                for kind in self._COLUMN_DEF_KINDS:
+                    nid = local_map.get((name, kind, probe_schema))
+                    if nid is not None:
+                        return nid
+            for key, nid in local_map.items():
+                if key[0] == name and key[1] in self._COLUMN_DEF_KINDS:
+                    return nid
+
+        # Graph fallback — same-repo only. resolve_node's internal
+        # kind-relaxed fallback covers table/view/source/query in one call,
+        # so we don't iterate kinds here.
+        for name in candidates:
+            if schema:
+                nid = self.graph.resolve_node(
+                    name, "table", repo_id, schema=schema, same_repo_only=True,
+                )
+                if nid:
+                    return nid
+            nid = self.graph.resolve_node(
+                name, "table", repo_id, same_repo_only=True,
+            )
+            if nid:
+                return nid
+        return None
 
     def _resolve_edge_endpoint(
         self,

--- a/src/sqlprism/core/naming.py
+++ b/src/sqlprism/core/naming.py
@@ -1,0 +1,32 @@
+"""Qualified-identifier parsing shared across the indexer and language renderers."""
+
+from __future__ import annotations
+
+import sqlglot
+from sqlglot import exp
+
+
+def parse_qualified_name(raw: str) -> tuple[str, str | None]:
+    """Split a possibly quoted/qualified identifier into ``(base_name, schema)``.
+
+    Handles ``"catalog"."schema"."name"`` (3-part), ``"schema"."name"``
+    (2-part), ``schema.name`` (unquoted), bare names, and single quoted
+    identifiers that themselves contain dots (e.g. ``"weird.name"`` →
+    base ``weird.name``, not ``name``). Falls back to a string split if
+    sqlglot cannot parse the input.
+    """
+    if not raw:
+        return raw, None
+    try:
+        table = exp.to_table(raw)
+        base = table.name
+        schema = table.db or None
+        if base:
+            return base, schema
+    except (sqlglot.errors.ParseError, ValueError):
+        pass
+    stripped = raw.replace('"."', ".").strip('"')
+    parts = stripped.split(".")
+    base = parts[-1] or raw
+    schema = parts[-2] if len(parts) >= 2 and parts[-2] else None
+    return base, schema

--- a/src/sqlprism/languages/sqlmesh.py
+++ b/src/sqlprism/languages/sqlmesh.py
@@ -19,6 +19,7 @@ import textwrap
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
+from sqlprism.core.naming import parse_qualified_name
 from sqlprism.languages.sql import SqlParser
 from sqlprism.languages.utils import build_env, enrich_nodes, find_venv_dir
 from sqlprism.types import ColumnDefResult, ParseResult
@@ -122,8 +123,8 @@ def _model_table_keys(model_name: str) -> list[str]:
     Downstream SQL may reference either the fully-qualified form or the bare
     base name, so populate both so ``qualify_columns`` resolves in either case.
     """
+    base, _schema = parse_qualified_name(model_name)
     stripped = model_name.replace('"."', ".").strip('"')
-    base = stripped.rsplit(".", 1)[-1]
     return [stripped] if stripped == base else [stripped, base]
 
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -2756,6 +2756,94 @@ def test_reindex_sqlmesh_cross_repo_select_star_lineage_true_mesh(tmp_path):
     assert ("stg_orders", "customer_id") in hops, \
         f"expected (stg_orders, customer_id) in chain, got {hops}"
 
+    # Upstream INT types must persist cross-repo — catches the regression
+    # where columns fall back to TEXT from the column_usage path.
+    upstream_repo_id = db._execute_read(
+        "SELECT repo_id FROM repos WHERE name = ?", ["platform"]
+    ).fetchone()[0]
+    catalog = db.get_table_columns(upstream_repo_id)
+    assert catalog.get("stg_orders", {}).get("customer_id") == "INT", \
+        f"expected INT type to survive, got {catalog.get('stg_orders')}"
+
+
+@pytest.mark.xfail(
+    reason="Blocked by #125 — reindex_dbt never produces ColumnDefResult from "
+           "schema.yml / catalog.json, so upstream dbt types can't feed a "
+           "downstream sibling repo's schema catalog. Preserves the dbt-mesh "
+           "regression signal the original #124/#125 xfail carried.",
+    strict=True,
+)
+def test_reindex_dbt_cross_repo_select_star_lineage_true_mesh(tmp_path):
+    """True dbt→sqlmesh mesh — pinned as xfail until #125 persists dbt columns."""
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    # ── Upstream: minimal dbt project with a single staging model ──
+    upstream = tmp_path / "platform"
+    upstream.mkdir()
+    (upstream / "dbt_project.yml").write_text("name: platform\n")
+    (upstream / ".venv").mkdir()
+    compiled = upstream / "target" / "compiled" / "platform" / "models" / "staging"
+    compiled.mkdir(parents=True)
+    (compiled / "stg_orders.sql").write_text(
+        "SELECT customer_id, order_id FROM raw.orders"
+    )
+    manifest = {
+        "nodes": {
+            "model.platform.stg_orders": {
+                "resource_type": "model",
+                "package_name": "platform",
+                "name": "stg_orders",
+                "path": "staging/stg_orders.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        "sources": {},
+    }
+    (upstream / "target" / "manifest.json").write_text(json.dumps(manifest))
+    # schema.yml declares column types — #125 gap: this isn't persisted today.
+    (upstream / "models" / "staging").mkdir(parents=True)
+    (upstream / "models" / "staging" / "schema.yml").write_text(
+        "version: 2\nmodels:\n"
+        "  - name: stg_orders\n"
+        "    columns:\n"
+        "      - name: customer_id\n        data_type: INT\n"
+        "      - name: order_id\n        data_type: INT\n"
+    )
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        indexer.reindex_dbt(repo_name="platform", project_path=str(upstream), dialect="duckdb")
+
+    # ── Downstream: sqlmesh repo selecting * from the dbt model ──
+    downstream_path = tmp_path / "finance"
+    downstream_path.mkdir()
+    downstream_models = {
+        '"finance"."orders"': (
+            "WITH orders AS (SELECT * FROM stg_orders) "
+            "SELECT customer_id FROM orders"
+        ),
+    }
+    with _mock_render_raw(indexer, downstream_models, {}):
+        indexer.reindex_sqlmesh("finance", downstream_path)
+
+    rows = db._execute_read(
+        "SELECT DISTINCT hop_table, hop_column "
+        "FROM column_lineage cl "
+        "JOIN files f ON cl.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND cl.output_node = ? AND cl.output_column = ?",
+        ["finance", "orders", "customer_id"],
+    ).fetchall()
+    hops = {(r[0], r[1]) for r in rows}
+    assert ("stg_orders", "customer_id") in hops, \
+        f"expected (stg_orders, customer_id) in chain, got {hops}"
+
 
 async def test_trace_column_lineage_mcp_tool_traverses_select_star(tmp_path):
     """AC #1: the MCP ``trace_column_lineage`` tool (not just the raw table)
@@ -2836,10 +2924,10 @@ def test_reindex_sqlmesh_populates_columns_table(tmp_path, caplog):
         ["platform"],
     ).fetchall()
 
-    assert len(rows) == 2, f"expected two column rows, got {rows}"
-    names = {(r[0], r[1], r[2], r[3]) for r in rows}
-    assert ("stg_orders", "customer_id", "INT", "sqlmesh_schema") in names
-    assert ("stg_orders", "order_id", "INT", "sqlmesh_schema") in names
+    assert rows == [
+        ("stg_orders", "customer_id", "INT", "sqlmesh_schema"),
+        ("stg_orders", "order_id", "INT", "sqlmesh_schema"),
+    ]
 
     assert not any(
         "Column def skipped: cannot resolve node" in rec.getMessage()
@@ -2886,7 +2974,7 @@ def test_insert_parse_result_resolves_query_kind_for_columns():
     from sqlprism.core.graph import GraphDB
     from sqlprism.core.indexer import Indexer
 
-    db = GraphDB()
+    db = GraphDB(":memory:")
     indexer = Indexer(db)
     repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sqlmesh")
 
@@ -2926,7 +3014,7 @@ def test_insert_parse_result_strips_qualified_column_def_names():
     from sqlprism.core.graph import GraphDB
     from sqlprism.core.indexer import Indexer
 
-    db = GraphDB()
+    db = GraphDB(":memory:")
     indexer = Indexer(db)
     repo_id = db.upsert_repo("platform", "/tmp/platform", repo_type="sqlmesh")
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -2713,15 +2713,9 @@ def test_reindex_sqlmesh_cross_repo_select_star_lineage_via_sql_upstream(tmp_pat
         f"expected (stg_orders, customer_id) in chain, got {hops}"
 
 
-@pytest.mark.xfail(
-    reason="Blocked by #124 (sqlmesh column defs dropped on insert) and #125 "
-           "(dbt column defs never produced). The in-parse schema catalog "
-           "doesn't reach a sibling repo through the graph until columns are "
-           "persisted on the upstream side.",
-    strict=True,
-)
 def test_reindex_sqlmesh_cross_repo_select_star_lineage_true_mesh(tmp_path):
-    """True sqlmesh→sqlmesh mesh — pinned as xfail until #124 persists columns."""
+    """True sqlmesh→sqlmesh mesh — upstream column persistence (#124) carries
+    types into the downstream schema catalog via the graph."""
     from sqlprism.core.graph import GraphDB
     from sqlprism.core.indexer import Indexer
 
@@ -2810,3 +2804,173 @@ async def test_trace_column_lineage_mcp_tool_traverses_select_star(tmp_path):
     payload = repr(result)
     assert "stg_orders" in payload, f"stg_orders missing from trace: {payload}"
     assert "customer_id" in payload, f"customer_id missing from trace: {payload}"
+
+
+def test_reindex_sqlmesh_populates_columns_table(tmp_path, caplog):
+    """sqlmesh column_schemas land in the `columns` table under source='sqlmesh_schema'."""
+    import logging
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    raw_models = {
+        '"platform"."stg_orders"': "SELECT customer_id, order_id FROM raw.orders",
+    }
+    column_schemas = {
+        '"platform"."stg_orders"': {"customer_id": "INT", "order_id": "INT"},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="sqlprism.core.indexer"):
+        with _mock_render_raw(indexer, raw_models, column_schemas):
+            indexer.reindex_sqlmesh("platform", tmp_path)
+
+    rows = db._execute_read(
+        "SELECT n.name, c.column_name, c.data_type, c.source "
+        "FROM columns c JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? ORDER BY c.column_name",
+        ["platform"],
+    ).fetchall()
+
+    assert len(rows) == 2, f"expected two column rows, got {rows}"
+    names = {(r[0], r[1], r[2], r[3]) for r in rows}
+    assert ("stg_orders", "customer_id", "INT", "sqlmesh_schema") in names
+    assert ("stg_orders", "order_id", "INT", "sqlmesh_schema") in names
+
+    assert not any(
+        "Column def skipped: cannot resolve node" in rec.getMessage()
+        for rec in caplog.records
+    ), f"unexpected skip warning(s): {[r.getMessage() for r in caplog.records]}"
+
+    db.close()
+
+
+def test_sqlmesh_columns_visible_in_schema_catalog(tmp_path):
+    """GraphDB.get_table_columns returns real sqlmesh types, not the TEXT fallback."""
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    raw_models = {
+        '"platform"."stg_orders"': "SELECT customer_id, order_id FROM raw.orders",
+    }
+    column_schemas = {
+        '"platform"."stg_orders"': {"customer_id": "INT", "order_id": "INT"},
+    }
+
+    with _mock_render_raw(indexer, raw_models, column_schemas):
+        indexer.reindex_sqlmesh("platform", tmp_path)
+
+    repo_id = db._execute_read(
+        "SELECT repo_id FROM repos WHERE name = ?", ["platform"]
+    ).fetchone()[0]
+
+    catalog = db.get_table_columns(repo_id)
+
+    assert "stg_orders" in catalog, f"stg_orders missing from catalog: {catalog}"
+    assert catalog["stg_orders"].get("customer_id") == "INT", \
+        f"expected customer_id=INT, got {catalog['stg_orders']}"
+    assert catalog["stg_orders"].get("order_id") == "INT"
+
+    db.close()
+
+
+def test_insert_parse_result_resolves_query_kind_for_columns():
+    """A kind='query' node is a valid target for a ColumnDefResult insert."""
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    db = GraphDB()
+    indexer = Indexer(db)
+    repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sqlmesh")
+
+    with db.write_transaction():
+        file_id = db.insert_file(repo_id, "stg_orders.sql", "sql", "abc")
+
+    result = ParseResult(
+        language="sql",
+        nodes=[NodeResult(kind="query", name="stg_orders")],
+        columns=[
+            ColumnDefResult(
+                node_name="stg_orders", column_name="customer_id",
+                data_type="INT", position=0, source="sqlmesh_schema",
+            ),
+        ],
+    )
+    stats = {
+        "nodes_added": 0, "edges_added": 0, "column_usage_added": 0,
+        "columns_added": 0, "lineage_chains": 0,
+    }
+
+    with db.write_transaction():
+        indexer._insert_parse_result(result, file_id, repo_id, stats)
+
+    rows = db._execute_read(
+        "SELECT n.name, n.kind, c.column_name, c.data_type, c.source "
+        "FROM columns c JOIN nodes n ON c.node_id = n.node_id"
+    ).fetchall()
+    assert rows == [("stg_orders", "query", "customer_id", "INT", "sqlmesh_schema")]
+    assert stats["columns_added"] == 1
+
+    db.close()
+
+
+def test_insert_parse_result_strips_qualified_column_def_names():
+    """Fully-qualified ColumnDefResult.node_name resolves to an existing base-name node."""
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    db = GraphDB()
+    indexer = Indexer(db)
+    repo_id = db.upsert_repo("platform", "/tmp/platform", repo_type="sqlmesh")
+
+    with db.write_transaction():
+        file_id = db.insert_file(repo_id, "stg_orders.sql", "sql", "abc")
+
+    # First pass: create the node under the bare base name.
+    seed = ParseResult(
+        language="sql",
+        nodes=[NodeResult(kind="query", name="stg_orders")],
+    )
+    seed_stats = {
+        "nodes_added": 0, "edges_added": 0, "column_usage_added": 0,
+        "columns_added": 0, "lineage_chains": 0,
+    }
+    with db.write_transaction():
+        indexer._insert_parse_result(seed, file_id, repo_id, seed_stats)
+
+    # Second pass: ColumnDefResult uses the fully-qualified form.
+    with db.write_transaction():
+        file_id2 = db.insert_file(repo_id, "stg_orders_cols.sql", "sql", "def")
+    defs = ParseResult(
+        language="sql",
+        columns=[
+            ColumnDefResult(
+                node_name='"platform"."stg_orders"', column_name="customer_id",
+                data_type="INT", position=0, source="sqlmesh_schema",
+            ),
+        ],
+    )
+    stats = {
+        "nodes_added": 0, "edges_added": 0, "column_usage_added": 0,
+        "columns_added": 0, "lineage_chains": 0,
+    }
+    with db.write_transaction():
+        indexer._insert_parse_result(defs, file_id2, repo_id, stats)
+
+    node_id = db._execute_read(
+        "SELECT node_id FROM nodes WHERE name = 'stg_orders' AND kind = 'query'"
+    ).fetchone()[0]
+    rows = db._execute_read(
+        "SELECT node_id, column_name, data_type, source FROM columns"
+    ).fetchall()
+    assert rows == [(node_id, "customer_id", "INT", "sqlmesh_schema")]
+    assert stats["columns_added"] == 1
+
+    db.close()


### PR DESCRIPTION
Closes #124

## Summary
- Normalize fully-qualified quoted names (`"platform"."stg_orders"` → `stg_orders`) in `_insert_parse_result` before local-map / `resolve_node` lookup so sqlmesh `ColumnDefResult` entries resolve to the base-name node the parser stores.
- Add `query` alongside `table`/`view`/`source` in the allowed kind list, since rendered sqlmesh SQL is a bare `SELECT` that yields `kind='query'` for the file-level node.
- Unpins `test_reindex_sqlmesh_cross_repo_select_star_lineage_true_mesh` — it passes now that upstream sqlmesh columns land in the graph and feed the downstream schema catalog.

## Test Plan
| Scenario | Test | Status |
|----------|------|--------|
| sqlmesh model columns land in the graph | `test_reindex_sqlmesh_populates_columns_table` | ✅ passing |
| `get_table_columns` reports sqlmesh column types | `test_sqlmesh_columns_visible_in_schema_catalog` | ✅ passing |
| query-kind nodes accept column defs | `test_insert_parse_result_resolves_query_kind_for_columns` | ✅ passing |
| Fully-qualified names resolve to base-name nodes | `test_insert_parse_result_strips_qualified_column_def_names` | ✅ passing |
| Plain-SQL / dbt behavior unchanged | existing 605-test suite | ✅ all passing |
| True sqlmesh→sqlmesh mesh (previously xfail) | `test_reindex_sqlmesh_cross_repo_select_star_lineage_true_mesh` | ✅ passing (unpinned) |

Lint + type check: `uv run ruff check .` / `uv run ty check` — both clean.