### PR TITLE
fix-125-dbt-column-defs-persistence

### DIFF
--- a/src/sqlprism/core/indexer.py
+++ b/src/sqlprism/core/indexer.py
@@ -397,6 +397,16 @@ class Indexer:
             "lineage_chains": 0,
         }
 
+        # Clear any prior synthetic schema.yml sources file even when this
+        # run produces no sources — otherwise stale rows persist after a
+        # user removes a `sources:` entry, because the synthetic key
+        # wouldn't appear in `rendered` this run to trigger its own
+        # delete_file_data pass.
+        with self.graph.write_transaction():
+            self.graph.delete_file_data(
+                repo_id, self.dbt_renderer._SCHEMA_YML_SOURCES_PATH,
+            )
+
         for model_path, result in rendered.items():
             # Wrap delete + insert per model in a transaction for atomicity
             with self.graph.write_transaction():
@@ -664,6 +674,14 @@ class Indexer:
                 stats["errors"].append(f"{f.stem}: dbt compile failed: {e}")
                 stats["details"].append({"path": str(f), "status": "error", "reason": str(e)})
             return
+
+        # Same stale-source guard as the full reindex — every dbt render
+        # pass regenerates the synthetic schema.yml source file from the
+        # current YAML, so wipe the prior copy before re-insertion.
+        with self.graph.write_transaction():
+            self.graph.delete_file_data(
+                repo_id, self.dbt_renderer._SCHEMA_YML_SOURCES_PATH,
+            )
 
         # Insert rendered results
         for model_path, result in rendered.items():

--- a/src/sqlprism/languages/dbt.py
+++ b/src/sqlprism/languages/dbt.py
@@ -22,6 +22,7 @@ import logging
 import os
 import shlex
 import subprocess
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from sqlprism.languages.sql import SqlParser
@@ -30,6 +31,23 @@ from sqlprism.languages.utils import build_env, enrich_nodes, find_venv_dir
 from sqlprism.types import ColumnDefResult, EdgeResult, ParseResult
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _SchemaYmlSource:
+    """One ``sources:`` table parsed from schema.yml.
+
+    Keeps the source *family* and physical *schema/identifier* separate so
+    the indexer can target the exact graph node a referencing model created.
+    ``schema`` defaults to ``family`` when the YAML doesn't override it,
+    matching dbt's own default.
+    """
+
+    family: str
+    identifier: str
+    schema: str | None
+    database: str | None
+    columns: list[ColumnDefResult] = field(default_factory=list)
 
 
 def _manifest_columns_dict(columns: dict | None) -> dict[str, str | None]:
@@ -206,10 +224,20 @@ class DbtRenderer:
         # typically multi-MB on real projects.
         manifest = self._load_manifest(project_path)
 
-        # Walk schema.yml once per compile. Shared by the SELECT * catalog
-        # and the post-parse merge that persists `source='schema_yml'`
-        # columns into the graph.
-        schema_yml_per_model = self.extract_schema_yml(project_path)
+        # Walk schema.yml once per compile. The split form (models + sources
+        # kept apart) is the critical input for the post-parse merge — a
+        # flattened key can't safely distinguish a source from a model whose
+        # name happens to contain a dot. The catalog builder still uses the
+        # flat form via _schema_yml_columns.
+        schema_yml_models, schema_yml_sources = (
+            self._extract_schema_yml_by_kind(project_path)
+        )
+        schema_yml_flat: dict[str, list[ColumnDefResult]] = dict(schema_yml_models)
+        for src in schema_yml_sources:
+            key = (
+                f"{src.family}.{src.identifier}" if src.family else src.identifier
+            )
+            schema_yml_flat.setdefault(key, []).extend(src.columns)
 
         # Build an effective schema catalog that layers dbt-sourced columns
         # (manifest + schema.yml) over the graph-derived catalog. Needed so
@@ -223,7 +251,7 @@ class DbtRenderer:
         # schema.yml metadata, not via mid-run in-graph writes.
         effective_schema = self._build_effective_schema(
             project_path, parser, schema_catalog, manifest=manifest,
-            schema_yml_per_model=schema_yml_per_model,
+            schema_yml_per_model=schema_yml_flat,
         )
 
         # Only read files for selected models when filtering
@@ -295,11 +323,13 @@ class DbtRenderer:
         # Merge schema.yml column defs into matching ParseResults so the
         # `columns` table carries real types (`source='schema_yml'`),
         # winning over the inferred projection entries the parser emitted
-        # from the CTAS wrap. Source entries that don't align with any
-        # compiled model land in a synthetic ParseResult whose columns
-        # attach to source table nodes created by referencing models.
+        # from the CTAS wrap. Source entries go into a synthetic
+        # ParseResult whose columns attach to source table nodes created
+        # by referencing models. Models and sources are handed in
+        # separately so a partial reindex (``render_models(select=...)``)
+        # can't misclassify an unselected model as a source.
         self._merge_schema_yml_into_results(
-            results, schema_yml_per_model, parser,
+            results, schema_yml_models, schema_yml_sources, parser,
         )
 
         return results
@@ -673,7 +703,8 @@ class DbtRenderer:
     def _merge_schema_yml_into_results(
         self,
         results: dict[str, ParseResult],
-        schema_yml_per_model: dict[str, list[ColumnDefResult]],
+        schema_yml_models: dict[str, list[ColumnDefResult]],
+        schema_yml_sources: list[_SchemaYmlSource],
         parser: SqlParser,
     ) -> None:
         """Fold schema.yml ``ColumnDefResult`` entries into the render output.
@@ -681,45 +712,79 @@ class DbtRenderer:
         For each compiled model, schema.yml entries win per ``column_name``
         over the inferred projection the parser emitted — concrete types and
         descriptions replace name-only ``inferred`` rows. Schema.yml source
-        entries (keyed ``source_name.table_name``) get collected into one
-        synthetic ParseResult so their columns persist via the graph
-        fallback in ``Indexer._resolve_column_def_node`` (which resolves to
-        the source table node any referencing model has already created).
+        entries land in a synthetic ParseResult so their columns persist
+        via the graph fallback in ``Indexer._resolve_column_def_node``
+        (which resolves to the source table node any referencing model has
+        already created).
+
+        Models are only merged when their compiled ParseResult is present in
+        ``results`` — on a partial reindex where the caller passed
+        ``select=[...]``, documented models that aren't being re-rendered
+        are skipped rather than being misrouted to the synthetic source
+        file.
         """
-        if not schema_yml_per_model:
+        if not schema_yml_models and not schema_yml_sources:
             return
 
-        # Index compiled results by normalized file stem so schema.yml model
-        # keys (the raw model name) line up with the CTAS-wrapped node the
-        # parser stored.
+        # Index compiled results by normalized file stem so schema.yml
+        # model keys (the raw model name) line up with the CTAS-wrapped
+        # node the parser stored. Log a warning if two compiled files
+        # share a stem — schema.yml can only merge into one of them.
         stem_to_result: dict[str, tuple[str, ParseResult]] = {}
         for rel_path, pr in results.items():
             stem = Path(rel_path).stem
-            stem_to_result[parser._normalize_identifier(stem)] = (rel_path, pr)
-
-        source_col_defs: list[ColumnDefResult] = []
-
-        for raw_name, col_defs in schema_yml_per_model.items():
-            if not col_defs:
-                continue
-            normalized = parser._normalize_identifier(raw_name)
-
-            match = stem_to_result.get(normalized)
-            if match is not None:
-                _rel, pr = match
-                self._apply_schema_yml_to_parse_result(
-                    pr, node_name=normalized, col_defs=col_defs,
+            key = parser._normalize_identifier(stem)
+            if key in stem_to_result:
+                prior_path, _ = stem_to_result[key]
+                logger.warning(
+                    "Duplicate compiled model stem %s — schema.yml merge will"
+                    " only target %s, not %s",
+                    key, prior_path, rel_path,
                 )
                 continue
+            stem_to_result[key] = (rel_path, pr)
 
-            # Not a compiled model — treat as a source entry. The
-            # extract_schema_yml walker encodes sources as
-            # ``source_name.table_name``; use the table segment as the
-            # physical node name (the parser stored source references
-            # under the identifier, not the source family name).
-            table_name = raw_name.rsplit(".", 1)[-1]
-            node_name = parser._normalize_identifier(table_name)
-            for c in col_defs:
+        for model_name, col_defs in schema_yml_models.items():
+            if not col_defs:
+                continue
+            normalized = parser._normalize_identifier(model_name)
+            match = stem_to_result.get(normalized)
+            if match is None:
+                # No compiled match — on partial reindex this is expected
+                # for unselected models. Skip rather than mislabel as a
+                # source.
+                continue
+            _rel, pr = match
+            self._apply_schema_yml_to_parse_result(
+                pr, node_name=normalized, col_defs=col_defs,
+            )
+            self._renumber_columns_for_node(pr.columns, normalized)
+
+        source_col_defs: list[ColumnDefResult] = []
+        seen_source_targets: dict[str, tuple[str | None, str]] = {}
+        for src in schema_yml_sources:
+            if not src.columns:
+                continue
+            identifier = parser._normalize_identifier(src.identifier)
+            schema = (
+                parser._normalize_identifier(src.schema) if src.schema else None
+            )
+            # Qualify the node_name with the source's physical schema so
+            # two sources sharing a bare identifier across different
+            # schemas resolve to their own graph nodes (collisions are
+            # otherwise silent — UNIQUE upsert makes the last writer win).
+            node_name = f'"{schema}"."{identifier}"' if schema else identifier
+
+            prior = seen_source_targets.get(node_name)
+            if prior is not None:
+                logger.warning(
+                    "Duplicate schema.yml source target %s (families %s vs %s)"
+                    " — later columns will clobber earlier on the same node",
+                    node_name, prior[1], src.family,
+                )
+            seen_source_targets[node_name] = (schema, src.family)
+
+            for c in src.columns:
                 source_col_defs.append(
                     ColumnDefResult(
                         node_name=node_name,
@@ -732,9 +797,28 @@ class DbtRenderer:
                 )
 
         if source_col_defs:
+            # Renumber each target node's columns sequentially so entries
+            # merged from distinct source families don't share positions.
+            by_node: dict[str, list[ColumnDefResult]] = {}
+            for c in source_col_defs:
+                by_node.setdefault(c.node_name, []).append(c)
+            flattened: list[ColumnDefResult] = []
+            for target_name, rows in by_node.items():
+                rows.sort(key=lambda r: (r.position if r.position is not None else 0))
+                flattened.extend(
+                    ColumnDefResult(
+                        node_name=target_name,
+                        column_name=r.column_name,
+                        data_type=r.data_type,
+                        position=i,
+                        source=r.source,
+                        description=r.description,
+                    )
+                    for i, r in enumerate(rows)
+                )
             results[self._SCHEMA_YML_SOURCES_PATH] = ParseResult(
                 language="sql",
-                columns=source_col_defs,
+                columns=flattened,
             )
 
     @staticmethod
@@ -764,6 +848,41 @@ class DbtRenderer:
                     source="schema_yml",
                     description=c.description,
                 )
+            )
+
+    @staticmethod
+    def _renumber_columns_for_node(
+        columns: list[ColumnDefResult],
+        node_name: str,
+    ) -> None:
+        """Reassign ``position`` 0..N-1 on every row targeting ``node_name``.
+
+        Merging schema.yml rows (carrying their YAML ordinals) with surviving
+        CTAS-inferred rows (carrying SELECT ordinals) yields duplicate
+        positions on a single node. Renumbering stably preserves the current
+        relative order — inferred rows come first (the parser appends them
+        before the merge writes schema.yml rows) — so ``position`` stays
+        monotonic for consumers that order by it.
+        """
+        targets = [(i, c) for i, c in enumerate(columns) if c.node_name == node_name]
+        if not targets:
+            return
+        targets.sort(
+            key=lambda pair: (
+                pair[1].position if pair[1].position is not None else 0,
+                pair[0],
+            )
+        )
+        for new_pos, (orig_idx, c) in enumerate(targets):
+            if c.position == new_pos:
+                continue
+            columns[orig_idx] = ColumnDefResult(
+                node_name=c.node_name,
+                column_name=c.column_name,
+                data_type=c.data_type,
+                position=new_pos,
+                source=c.source,
+                description=c.description,
             )
 
     def _run_dbt_compile(
@@ -852,7 +971,9 @@ class DbtRenderer:
         Scans all ``*.yml`` and ``*.yaml`` files under the project's ``models/``
         directory for model and source entries with ``columns:`` lists. Returns
         a mapping of model name to ``ColumnDefResult`` entries with
-        ``source='schema_yml'``.
+        ``source='schema_yml'``. Sources are keyed as
+        ``"{source_family}.{table_name}"`` for backwards compat with the
+        pre-existing catalog flatten.
 
         Args:
             project_path: Path to dbt project dir (containing ``models/``).
@@ -860,16 +981,53 @@ class DbtRenderer:
         Returns:
             Dict mapping model name -> list of ``ColumnDefResult``.
         """
+        models, sources = self._extract_schema_yml_by_kind(project_path)
+        result: dict[str, list[ColumnDefResult]] = dict(models)
+        for src in sources:
+            key = (
+                f"{src.family}.{src.identifier}" if src.family else src.identifier
+            )
+            existing = result.get(key)
+            if existing is None:
+                result[key] = list(src.columns)
+            else:
+                existing.extend(src.columns)
+        return result
+
+    def _extract_schema_yml_by_kind(
+        self,
+        project_path: str | Path,
+    ) -> tuple[dict[str, list[ColumnDefResult]], list[_SchemaYmlSource]]:
+        """Parse schema.yml into separated models and sources.
+
+        Callers that need to distinguish models from sources (the critical
+        use case: the indexer merge can't guess from a flattened key whether
+        ``raw.users`` is a source table or a model named with a dot) should
+        consume this directly. ``extract_schema_yml`` remains the flat-form
+        public API for the SELECT * catalog builder and existing tests.
+
+        Source entries preserve the source's family, physical schema
+        (``sources[].schema`` defaulting to ``sources[].name``), optional
+        database, and the physical ``identifier`` (``tables[].identifier``
+        defaulting to ``tables[].name``). Both a schema and identifier
+        override at dbt's semantic layer must flow through to the graph —
+        two sources sharing a bare name across different schemas must
+        resolve to distinct nodes.
+        """
         import yaml
 
         project_path = Path(project_path).resolve()
         models_dir = project_path / "models"
+        models: dict[str, list[ColumnDefResult]] = {}
+        sources: list[_SchemaYmlSource] = []
         if not models_dir.exists():
-            return {}
+            return models, sources
 
-        result: dict[str, list[ColumnDefResult]] = {}
-
+        # Skip the rglob if no YAML files exist at all — avoids a full
+        # directory traversal on projects that aren't documented.
         yml_files = [f for f in models_dir.rglob("*") if f.suffix in (".yml", ".yaml")]
+        if not yml_files:
+            return models, sources
         for yml_file in yml_files:
             try:
                 data = yaml.safe_load(yml_file.read_text())
@@ -880,30 +1038,47 @@ class DbtRenderer:
             if not isinstance(data, dict):
                 continue
 
-            # Extract columns from models: entries
+            # Models — keyed by plain model name.
             for model in data.get("models") or []:
                 if not isinstance(model, dict):
                     continue
                 model_name = model.get("name")
                 if not model_name:
                     continue
-                self._extract_yml_columns(model_name, model.get("columns"), result)
+                self._extract_yml_columns(model_name, model.get("columns"), models)
 
-            # Extract columns from sources: entries
+            # Sources — keep family/schema/identifier separate.
             for source_entry in data.get("sources") or []:
                 if not isinstance(source_entry, dict):
                     continue
-                source_name = source_entry.get("name", "")
+                family = source_entry.get("name") or ""
+                source_schema = source_entry.get("schema") or family or None
+                source_database = source_entry.get("database") or None
                 for table_entry in source_entry.get("tables") or []:
                     if not isinstance(table_entry, dict):
                         continue
                     table_name = table_entry.get("name")
                     if not table_name:
                         continue
-                    full_name = f"{source_name}.{table_name}" if source_name else table_name
-                    self._extract_yml_columns(full_name, table_entry.get("columns"), result)
+                    identifier = table_entry.get("identifier") or table_name
+                    per_table: dict[str, list[ColumnDefResult]] = {}
+                    self._extract_yml_columns(
+                        identifier, table_entry.get("columns"), per_table,
+                    )
+                    col_defs = per_table.get(identifier, [])
+                    if not col_defs:
+                        continue
+                    sources.append(
+                        _SchemaYmlSource(
+                            family=family,
+                            identifier=identifier,
+                            schema=source_schema,
+                            database=source_database,
+                            columns=col_defs,
+                        )
+                    )
 
-        return result
+        return models, sources
 
     @staticmethod
     def _extract_yml_columns(

--- a/src/sqlprism/languages/dbt.py
+++ b/src/sqlprism/languages/dbt.py
@@ -206,6 +206,11 @@ class DbtRenderer:
         # typically multi-MB on real projects.
         manifest = self._load_manifest(project_path)
 
+        # Walk schema.yml once per compile. Shared by the SELECT * catalog
+        # and the post-parse merge that persists `source='schema_yml'`
+        # columns into the graph.
+        schema_yml_per_model = self.extract_schema_yml(project_path)
+
         # Build an effective schema catalog that layers dbt-sourced columns
         # (manifest + schema.yml) over the graph-derived catalog. Needed so
         # SELECT * through CTEs can expand on a fresh index — before any
@@ -218,6 +223,7 @@ class DbtRenderer:
         # schema.yml metadata, not via mid-run in-graph writes.
         effective_schema = self._build_effective_schema(
             project_path, parser, schema_catalog, manifest=manifest,
+            schema_yml_per_model=schema_yml_per_model,
         )
 
         # Only read files for selected models when filtering
@@ -285,6 +291,16 @@ class DbtRenderer:
                 if key not in existing:
                     pr.edges.append(edge)
                     existing.add(key)
+
+        # Merge schema.yml column defs into matching ParseResults so the
+        # `columns` table carries real types (`source='schema_yml'`),
+        # winning over the inferred projection entries the parser emitted
+        # from the CTAS wrap. Source entries that don't align with any
+        # compiled model land in a synthetic ParseResult whose columns
+        # attach to source table nodes created by referencing models.
+        self._merge_schema_yml_into_results(
+            results, schema_yml_per_model, parser,
+        )
 
         return results
 
@@ -488,6 +504,7 @@ class DbtRenderer:
         parser: SqlParser,
         schema_catalog: dict | None,
         manifest: dict | None = None,
+        schema_yml_per_model: dict[str, list[ColumnDefResult]] | None = None,
     ) -> dict[str, dict[str, str]]:
         """Merge dbt-sourced column schemas on top of the graph schema catalog.
 
@@ -502,8 +519,13 @@ class DbtRenderer:
           when the manifest's type is concrete — a ``None`` manifest type
           never clobbers a typed ``schema.yml`` entry. Manifest-only columns
           are added as ``"TEXT"`` so ``SELECT *`` expansion can see them.
+
+        ``schema_yml_per_model`` may be passed pre-parsed to avoid a second
+        disk walk when the caller already ran ``extract_schema_yml``.
         """
-        yml_overlay = self._schema_yml_columns(project_path, parser)
+        yml_overlay = self._schema_yml_columns(
+            project_path, parser, schema_yml_per_model=schema_yml_per_model,
+        )
         manifest_overlay = self._extract_manifest_columns(
             project_path, parser, manifest=manifest,
         )
@@ -619,6 +641,7 @@ class DbtRenderer:
         self,
         project_path: Path,
         parser: SqlParser,
+        schema_yml_per_model: dict[str, list[ColumnDefResult]] | None = None,
     ) -> dict[str, dict[str, str]]:
         """Column schemas from ``schema.yml`` files as a flat catalog.
 
@@ -627,7 +650,11 @@ class DbtRenderer:
         Entries with no columns are dropped so they can't short-circuit the
         ``if not overlays`` guard in ``_build_effective_schema``.
         """
-        per_model = self.extract_schema_yml(project_path)
+        per_model = (
+            schema_yml_per_model
+            if schema_yml_per_model is not None
+            else self.extract_schema_yml(project_path)
+        )
         out: dict[str, dict[str, str]] = {}
         for name, col_defs in per_model.items():
             if not col_defs:
@@ -637,6 +664,107 @@ class DbtRenderer:
             for c in col_defs:
                 bucket[c.column_name] = c.data_type or "TEXT"
         return out
+
+    # Synthetic ParseResult path that carries schema.yml `sources:` column
+    # defs into the graph. A stable key lets `delete_file_data` clean it up
+    # between reindex runs the same way it does for real compiled files.
+    _SCHEMA_YML_SOURCES_PATH = "__schema_yml_sources__.sql"
+
+    def _merge_schema_yml_into_results(
+        self,
+        results: dict[str, ParseResult],
+        schema_yml_per_model: dict[str, list[ColumnDefResult]],
+        parser: SqlParser,
+    ) -> None:
+        """Fold schema.yml ``ColumnDefResult`` entries into the render output.
+
+        For each compiled model, schema.yml entries win per ``column_name``
+        over the inferred projection the parser emitted — concrete types and
+        descriptions replace name-only ``inferred`` rows. Schema.yml source
+        entries (keyed ``source_name.table_name``) get collected into one
+        synthetic ParseResult so their columns persist via the graph
+        fallback in ``Indexer._resolve_column_def_node`` (which resolves to
+        the source table node any referencing model has already created).
+        """
+        if not schema_yml_per_model:
+            return
+
+        # Index compiled results by normalized file stem so schema.yml model
+        # keys (the raw model name) line up with the CTAS-wrapped node the
+        # parser stored.
+        stem_to_result: dict[str, tuple[str, ParseResult]] = {}
+        for rel_path, pr in results.items():
+            stem = Path(rel_path).stem
+            stem_to_result[parser._normalize_identifier(stem)] = (rel_path, pr)
+
+        source_col_defs: list[ColumnDefResult] = []
+
+        for raw_name, col_defs in schema_yml_per_model.items():
+            if not col_defs:
+                continue
+            normalized = parser._normalize_identifier(raw_name)
+
+            match = stem_to_result.get(normalized)
+            if match is not None:
+                _rel, pr = match
+                self._apply_schema_yml_to_parse_result(
+                    pr, node_name=normalized, col_defs=col_defs,
+                )
+                continue
+
+            # Not a compiled model — treat as a source entry. The
+            # extract_schema_yml walker encodes sources as
+            # ``source_name.table_name``; use the table segment as the
+            # physical node name (the parser stored source references
+            # under the identifier, not the source family name).
+            table_name = raw_name.rsplit(".", 1)[-1]
+            node_name = parser._normalize_identifier(table_name)
+            for c in col_defs:
+                source_col_defs.append(
+                    ColumnDefResult(
+                        node_name=node_name,
+                        column_name=c.column_name,
+                        data_type=c.data_type,
+                        position=c.position,
+                        source="schema_yml",
+                        description=c.description,
+                    )
+                )
+
+        if source_col_defs:
+            results[self._SCHEMA_YML_SOURCES_PATH] = ParseResult(
+                language="sql",
+                columns=source_col_defs,
+            )
+
+    @staticmethod
+    def _apply_schema_yml_to_parse_result(
+        pr: ParseResult,
+        node_name: str,
+        col_defs: list[ColumnDefResult],
+    ) -> None:
+        """Replace existing columns on ``node_name`` that collide with schema.yml.
+
+        Schema.yml wins over ``inferred`` rows — a documented type must not
+        be shadowed by a name-only entry the parser emitted from the CTAS
+        projection. Non-colliding entries from either side are preserved.
+        """
+        incoming = {c.column_name for c in col_defs}
+        pr.columns = [
+            c for c in pr.columns
+            if not (c.node_name == node_name and c.column_name in incoming)
+        ]
+        for c in col_defs:
+            pr.columns.append(
+                ColumnDefResult(
+                    node_name=node_name,
+                    column_name=c.column_name,
+                    data_type=c.data_type,
+                    position=c.position,
+                    source="schema_yml",
+                    description=c.description,
+                )
+            )
 
     def _run_dbt_compile(
         self,

--- a/src/sqlprism/languages/sql.py
+++ b/src/sqlprism/languages/sql.py
@@ -281,35 +281,40 @@ class SqlParser:
         # tables (CTAS). dbt compiled SQL wraps every model as
         # `CREATE TABLE "schema"."name" AS <SELECT>` — without inferring here,
         # the columns table stays empty for dbt regardless of schema.yml.
-        if stmt.expression and node_kind in ("table", "view"):
-            select_expr = stmt.expression
-            if isinstance(select_expr, (exp.Select, exp.Query)):
-                # Skip names already recorded from the explicit schema clause
-                # (e.g. `CREATE TABLE t (a INT) AS SELECT a, b ...`) so the
-                # declared type isn't shadowed by an `inferred` duplicate.
-                declared = {
-                    c.column_name for c in columns
-                    if c.node_name == name and c.source == "definition"
-                }
-                before = len(columns)
-                self._extract_inferred_columns(select_expr, name, columns)
-                if declared:
-                    columns[before:] = [
-                        c for c in columns[before:] if c.column_name not in declared
-                    ]
+        if stmt.expression and node_kind in ("table", "view") and (
+            isinstance(stmt.expression, exp.Query)
+        ):
+            # Skip names already recorded from the explicit schema clause
+            # (e.g. `CREATE TABLE t (a INT) AS SELECT a, b ...`) so the
+            # declared type isn't shadowed by an `inferred` duplicate.
+            declared = {
+                c.column_name for c in columns
+                if c.node_name == name and c.source == "definition"
+            }
+            inferred = self._build_inferred_columns(stmt.expression, name)
+            columns.extend(
+                c for c in inferred if c.column_name not in declared
+            )
 
-    def _extract_inferred_columns(
+    def _build_inferred_columns(
         self,
         select_expr: exp.Expression,
         node_name: str,
-        columns: list[ColumnDefResult],
-    ) -> None:
-        """Infer output column names from a SELECT expression."""
+    ) -> list[ColumnDefResult]:
+        """Infer output column rows from a SELECT expression.
+
+        Returns the newly-built rows instead of mutating a caller-supplied
+        list so the caller can filter them (e.g. drop names already covered
+        by an explicit schema clause) before committing. Mutating in-place
+        and then slicing on ``len(columns)`` was fragile — any future change
+        that also touched earlier entries would silently break dedup.
+        """
         # Find the outermost SELECT
         select = select_expr.find(exp.Select) if not isinstance(select_expr, exp.Select) else select_expr
         if not select or not select.expressions:
-            return
+            return []
 
+        rows: list[ColumnDefResult] = []
         for i, sel_col in enumerate(select.expressions):
             # Use alias if present, otherwise try to get column name
             if isinstance(sel_col, exp.Alias):
@@ -323,7 +328,7 @@ class SqlParser:
                 col_name = sel_col.alias_or_name if hasattr(sel_col, "alias_or_name") else None
 
             if col_name and col_name != "*":
-                columns.append(
+                rows.append(
                     ColumnDefResult(
                         node_name=node_name,
                         column_name=col_name,
@@ -331,6 +336,7 @@ class SqlParser:
                         source="inferred",
                     )
                 )
+        return rows
 
     def _extract_table_references(
         self,

--- a/src/sqlprism/languages/sql.py
+++ b/src/sqlprism/languages/sql.py
@@ -277,11 +277,26 @@ class SqlParser:
                         )
                     )
 
-        # Infer output columns from CREATE VIEW AS SELECT
-        if node_kind == "view" and stmt.expression:
+        # Infer output columns from CREATE ... AS SELECT for both views and
+        # tables (CTAS). dbt compiled SQL wraps every model as
+        # `CREATE TABLE "schema"."name" AS <SELECT>` — without inferring here,
+        # the columns table stays empty for dbt regardless of schema.yml.
+        if stmt.expression and node_kind in ("table", "view"):
             select_expr = stmt.expression
-            if isinstance(select_expr, exp.Select) or isinstance(select_expr, exp.Query):
+            if isinstance(select_expr, (exp.Select, exp.Query)):
+                # Skip names already recorded from the explicit schema clause
+                # (e.g. `CREATE TABLE t (a INT) AS SELECT a, b ...`) so the
+                # declared type isn't shadowed by an `inferred` duplicate.
+                declared = {
+                    c.column_name for c in columns
+                    if c.node_name == name and c.source == "definition"
+                }
+                before = len(columns)
                 self._extract_inferred_columns(select_expr, name, columns)
+                if declared:
+                    columns[before:] = [
+                        c for c in columns[before:] if c.column_name not in declared
+                    ]
 
     def _extract_inferred_columns(
         self,

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -2838,6 +2838,16 @@ def test_reindex_dbt_cross_repo_select_star_lineage_true_mesh(tmp_path):
     assert ("stg_orders", "customer_id") in hops, \
         f"expected (stg_orders, customer_id) in chain, got {hops}"
 
+    # Mirror the sqlmesh sibling's upstream-type assertion — the dbt mesh
+    # path must persist schema.yml types into the graph, not fall back to
+    # TEXT via column_usage. This is the exact regression #125 addresses.
+    upstream_repo_id = db._execute_read(
+        "SELECT repo_id FROM repos WHERE name = ?", ["platform"]
+    ).fetchone()[0]
+    catalog = db.get_table_columns(upstream_repo_id)
+    assert catalog.get("stg_orders", {}).get("customer_id") == "INT", \
+        f"expected INT from schema.yml to survive, got {catalog.get('stg_orders')}"
+
 
 async def test_trace_column_lineage_mcp_tool_traverses_select_star(tmp_path):
     """AC #1: the MCP ``trace_column_lineage`` tool (not just the raw table)
@@ -3221,8 +3231,8 @@ def test_dbt_columns_visible_in_schema_catalog(tmp_path):
 
     assert catalog.get("orders", {}).get("customer_id") == "bigint", catalog
     # CTAS-only column without schema.yml docs falls back to TEXT in the
-    # catalog, but must still be present — inferred emits name-only rows.
-    assert "only_col" in catalog.get("plain", {}), catalog
+    # catalog — pin the fallback value so the contract can't drift.
+    assert catalog.get("plain", {}).get("only_col") == "TEXT", catalog
     db.close()
 
 
@@ -3289,4 +3299,381 @@ def test_reindex_dbt_captures_source_columns(tmp_path):
         ("id", "bigint", "schema_yml"),
     ], rows
 
+    db.close()
+
+
+def test_reindex_dbt_drops_stale_schema_yml_sources(tmp_path):
+    """If a `sources:` entry disappears from schema.yml, its rows must be
+    cleared on the next reindex — the synthetic source file is deleted
+    unconditionally so stale columns don't persist after a YAML edit."""
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = _build_minimal_dbt_project(
+        tmp_path / "proj",
+        compiled_models={
+            "staging/stg_customers.sql": 'SELECT id FROM "raw"."customers"',
+        },
+        manifest_nodes={
+            "model.my_proj.stg_customers": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "stg_customers",
+                "path": "staging/stg_customers.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        schema_yml_sources=(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    tables:\n"
+            "      - name: customers\n"
+            "        columns:\n"
+            "          - name: id\n            data_type: bigint\n"
+        ),
+    )
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        indexer.reindex_dbt(
+            repo_name="proj", project_path=str(repo_dir), dialect="duckdb",
+        )
+
+    before = db._execute_read(
+        "SELECT count(*) FROM columns c "
+        "JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND n.name = ? AND c.source = ?",
+        ["proj", "customers", "schema_yml"],
+    ).fetchone()[0]
+    assert before == 1, "source row should exist before removal"
+
+    # Drop the source from schema.yml and re-index.
+    (repo_dir / "models" / "sources.yml").write_text(
+        "version: 2\nsources: []\n"
+    )
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        indexer.reindex_dbt(
+            repo_name="proj", project_path=str(repo_dir), dialect="duckdb",
+        )
+
+    after = db._execute_read(
+        "SELECT count(*) FROM columns c "
+        "JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND n.name = ? AND c.source = ?",
+        ["proj", "customers", "schema_yml"],
+    ).fetchone()[0]
+    assert after == 0, f"stale source rows should be gone, found {after}"
+
+    db.close()
+
+
+def test_reindex_files_dbt_merges_schema_yml(tmp_path):
+    """reindex_files() (the on-save fast path) must also merge schema.yml
+    into dbt ParseResults — otherwise a single-file save would silently
+    drop documented types and regress back to CTAS-inferred rows only."""
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = _build_minimal_dbt_project(
+        tmp_path / "proj",
+        compiled_models={
+            "staging/orders.sql": "SELECT customer_id FROM raw.orders",
+        },
+        manifest_nodes={
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "staging/orders.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        schema_yml_models=(
+            "version: 2\n"
+            "models:\n"
+            "  - name: orders\n"
+            "    columns:\n"
+            "      - name: customer_id\n"
+            "        data_type: bigint\n"
+        ),
+    )
+
+    # The on-save path expects the user to point at a source file — the
+    # dbt reindex path looks up the stem against the compiled tree.
+    src_file = repo_dir / "models" / "staging" / "orders.sql"
+    src_file.parent.mkdir(parents=True, exist_ok=True)
+    src_file.write_text("SELECT customer_id FROM {{ source('raw', 'orders') }}")
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+    db.upsert_repo("proj", str(repo_dir), repo_type="dbt")
+
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        stats = indexer.reindex_files(
+            paths=[str(src_file)],
+            repo_configs={"proj": {
+                "project_path": str(repo_dir),
+                "repo_type": "dbt",
+                "dialect": "duckdb",
+            }},
+        )
+
+    assert stats["reindexed"] == 1, stats
+    rows = db._execute_read(
+        "SELECT c.column_name, c.data_type, c.source "
+        "FROM columns c JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND n.name = ?",
+        ["proj", "orders"],
+    ).fetchall()
+    # schema.yml row beats the inferred row — bigint survives.
+    assert ("customer_id", "bigint", "schema_yml") in rows, rows
+    db.close()
+
+
+def test_reindex_dbt_source_identifier_and_schema_keyed_separately(tmp_path):
+    """Two sources sharing a bare identifier across different schemas must
+    attach their columns to distinct graph nodes. The fix qualifies the
+    node_name with the source schema, so they no longer collapse onto one
+    `users` row via the UNIQUE upsert."""
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = _build_minimal_dbt_project(
+        tmp_path / "proj",
+        compiled_models={
+            # Two staging models each reference a differently-schema'd
+            # source table that both happen to be called `users`.
+            "staging/a.sql": 'SELECT id FROM "raw"."users"',
+            "staging/b.sql": 'SELECT id FROM "prod"."users"',
+        },
+        manifest_nodes={
+            "model.my_proj.a": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "a",
+                "path": "staging/a.sql",
+                "depends_on": {"nodes": []},
+            },
+            "model.my_proj.b": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "b",
+                "path": "staging/b.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        schema_yml_sources=(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    schema: raw\n"
+            "    tables:\n"
+            "      - name: users\n"
+            "        columns:\n"
+            "          - name: raw_only\n            data_type: text\n"
+            "  - name: prod\n"
+            "    schema: prod\n"
+            "    tables:\n"
+            "      - name: users\n"
+            "        columns:\n"
+            "          - name: prod_only\n            data_type: text\n"
+        ),
+    )
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        indexer.reindex_dbt(
+            repo_name="proj", project_path=str(repo_dir), dialect="duckdb",
+        )
+
+    rows = db._execute_read(
+        "SELECT n.name, n.schema, c.column_name, c.source "
+        "FROM columns c JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND n.name = ? "
+        "ORDER BY n.schema, c.column_name",
+        ["proj", "users"],
+    ).fetchall()
+
+    by_schema: dict[str | None, set[str]] = {}
+    for name, schema, col_name, src in rows:
+        assert src == "schema_yml", rows
+        by_schema.setdefault(schema, set()).add(col_name)
+
+    # raw_only must only live under the raw users node; prod_only under prod.
+    assert by_schema.get("raw") == {"raw_only"}, by_schema
+    assert by_schema.get("prod") == {"prod_only"}, by_schema
+    db.close()
+
+
+def test_reindex_dbt_source_identifier_override(tmp_path):
+    """``sources.tables[].identifier`` overrides the logical ``name`` —
+    the physical table the compiled SQL references is what graph nodes
+    are keyed by, so columns must attach to the identifier."""
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = _build_minimal_dbt_project(
+        tmp_path / "proj",
+        compiled_models={
+            # Compiled SQL references the PHYSICAL name (customers_raw),
+            # not the logical source entry name (customers).
+            "staging/stg_customers.sql": 'SELECT id FROM "raw"."customers_raw"',
+        },
+        manifest_nodes={
+            "model.my_proj.stg_customers": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "stg_customers",
+                "path": "staging/stg_customers.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        schema_yml_sources=(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    schema: raw\n"
+            "    tables:\n"
+            "      - name: customers\n"
+            "        identifier: customers_raw\n"
+            "        columns:\n"
+            "          - name: id\n            data_type: bigint\n"
+        ),
+    )
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        indexer.reindex_dbt(
+            repo_name="proj", project_path=str(repo_dir), dialect="duckdb",
+        )
+
+    # Columns attached to the physical identifier, not the logical name.
+    phys_rows = db._execute_read(
+        "SELECT c.column_name, c.data_type, c.source "
+        "FROM columns c JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND n.name = ?",
+        ["proj", "customers_raw"],
+    ).fetchall()
+    assert phys_rows == [("id", "bigint", "schema_yml")], phys_rows
+
+    # And nothing landed on a phantom `customers` node.
+    logical_rows = db._execute_read(
+        "SELECT c.column_name "
+        "FROM columns c JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND n.name = ?",
+        ["proj", "customers"],
+    ).fetchall()
+    assert logical_rows == [], logical_rows
+    db.close()
+
+
+def test_reindex_dbt_model_and_source_same_bare_name_disambiguated(tmp_path):
+    """A model named ``customers`` and a ``raw.customers`` source entry must
+    not cross-pollinate: model columns attach to the compiled model node,
+    source columns to the source (via its physical schema)."""
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = _build_minimal_dbt_project(
+        tmp_path / "proj",
+        compiled_models={
+            # The model `customers` references the source — which gives
+            # the parser a table node for the source too.
+            "marts/customers.sql": 'SELECT id FROM "raw"."customers"',
+        },
+        manifest_nodes={
+            "model.my_proj.customers": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "customers",
+                "path": "marts/customers.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        schema_yml_models=(
+            "version: 2\n"
+            "models:\n"
+            "  - name: customers\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_type: bigint\n"
+            "        description: model-level id\n"
+        ),
+        schema_yml_sources=(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    schema: raw\n"
+            "    tables:\n"
+            "      - name: customers\n"
+            "        columns:\n"
+            "          - name: id\n"
+            "            data_type: text\n"
+            "            description: raw-source id\n"
+        ),
+    )
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        indexer.reindex_dbt(
+            repo_name="proj", project_path=str(repo_dir), dialect="duckdb",
+        )
+
+    rows = db._execute_read(
+        "SELECT n.name, n.schema, c.column_name, c.data_type, c.description "
+        "FROM columns c JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND n.name = ?",
+        ["proj", "customers"],
+    ).fetchall()
+
+    descriptions_by_schema = {r[1]: r[4] for r in rows}
+    types_by_schema = {r[1]: r[3] for r in rows}
+
+    # The source row under schema=raw stays distinct from the model row
+    # (which has no schema or a dbt-assigned path-based schema).
+    assert descriptions_by_schema.get("raw") == "raw-source id", rows
+    assert types_by_schema.get("raw") == "text", rows
+    # The model-level row must carry the model description, NOT the source.
+    model_rows = [r for r in rows if r[1] != "raw"]
+    assert model_rows, f"expected at least one non-raw row, got {rows}"
+    assert all(r[4] == "model-level id" for r in model_rows), model_rows
     db.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -3056,3 +3056,237 @@ def test_insert_parse_result_strips_qualified_column_def_names():
     assert stats["columns_added"] == 1
 
     db.close()
+
+
+# ── #125: dbt ColumnDefResult persistence ──
+
+
+def _build_minimal_dbt_project(
+    repo_dir,
+    *,
+    manifest_nodes: dict | None = None,
+    manifest_sources: dict | None = None,
+    compiled_models: dict[str, str] | None = None,
+    schema_yml_models: str | None = None,
+    schema_yml_sources: str | None = None,
+):
+    """Scaffold a fake compiled dbt project so reindex_dbt can run end-to-end
+    without a real dbt install. Returns the repo_dir."""
+    import json
+
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    (repo_dir / "dbt_project.yml").write_text("name: my_proj\n")
+    (repo_dir / ".venv").mkdir(exist_ok=True)
+
+    compiled = repo_dir / "target" / "compiled" / "my_proj" / "models"
+    compiled.mkdir(parents=True, exist_ok=True)
+    for rel, sql in (compiled_models or {}).items():
+        target = compiled / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(sql)
+
+    manifest = {
+        "nodes": manifest_nodes or {},
+        "sources": manifest_sources or {},
+    }
+    (repo_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    models_dir = repo_dir / "models"
+    models_dir.mkdir(exist_ok=True)
+    if schema_yml_models:
+        (models_dir / "schema.yml").write_text(schema_yml_models)
+    if schema_yml_sources:
+        (models_dir / "sources.yml").write_text(schema_yml_sources)
+
+    return repo_dir
+
+
+def test_reindex_dbt_persists_schema_yml_columns(tmp_path):
+    """schema.yml types and descriptions land in the `columns` table for
+    dbt-indexed models, beating the inferred projection emitted by the CTAS
+    wrap so documented types don't get shadowed."""
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = _build_minimal_dbt_project(
+        tmp_path / "proj",
+        compiled_models={
+            "staging/orders.sql": "SELECT customer_id, order_id FROM raw.orders",
+        },
+        manifest_nodes={
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "staging/orders.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        schema_yml_models=(
+            "version: 2\n"
+            "models:\n"
+            "  - name: orders\n"
+            "    columns:\n"
+            "      - name: customer_id\n"
+            "        data_type: bigint\n"
+            "        description: The customer reference\n"
+            "      - name: order_id\n"
+            "        data_type: bigint\n"
+        ),
+    )
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        indexer.reindex_dbt(
+            repo_name="proj", project_path=str(repo_dir), dialect="duckdb",
+        )
+
+    rows = db._execute_read(
+        "SELECT n.name, c.column_name, c.data_type, c.source, c.description "
+        "FROM columns c JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND n.name = ? "
+        "ORDER BY c.column_name",
+        ["proj", "orders"],
+    ).fetchall()
+
+    assert rows == [
+        ("orders", "customer_id", "bigint", "schema_yml", "The customer reference"),
+        ("orders", "order_id", "bigint", "schema_yml", None),
+    ], rows
+
+    db.close()
+
+
+def test_dbt_columns_visible_in_schema_catalog(tmp_path):
+    """GraphDB.get_table_columns returns real schema.yml types for dbt
+    models; CTAS-only columns still appear, but with the `TEXT` fallback
+    since no schema.yml documents them."""
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = _build_minimal_dbt_project(
+        tmp_path / "proj",
+        compiled_models={
+            "staging/orders.sql": "SELECT customer_id, order_id FROM raw.orders",
+            "staging/plain.sql": "SELECT only_col FROM raw.foo",
+        },
+        manifest_nodes={
+            "model.my_proj.orders": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "orders",
+                "path": "staging/orders.sql",
+                "depends_on": {"nodes": []},
+            },
+            "model.my_proj.plain": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "plain",
+                "path": "staging/plain.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        schema_yml_models=(
+            "version: 2\n"
+            "models:\n"
+            "  - name: orders\n"
+            "    columns:\n"
+            "      - name: customer_id\n"
+            "        data_type: bigint\n"
+        ),
+    )
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        indexer.reindex_dbt(
+            repo_name="proj", project_path=str(repo_dir), dialect="duckdb",
+        )
+
+    repo_id = db._execute_read(
+        "SELECT repo_id FROM repos WHERE name = ?", ["proj"]
+    ).fetchone()[0]
+    catalog = db.get_table_columns(repo_id)
+
+    assert catalog.get("orders", {}).get("customer_id") == "bigint", catalog
+    # CTAS-only column without schema.yml docs falls back to TEXT in the
+    # catalog, but must still be present — inferred emits name-only rows.
+    assert "only_col" in catalog.get("plain", {}), catalog
+    db.close()
+
+
+def test_reindex_dbt_captures_source_columns(tmp_path):
+    """schema.yml source entries attach to the source table node a model
+    references — even without compiled SQL for the source itself, the
+    `columns` table carries its documented columns under source='schema_yml'."""
+    from unittest.mock import MagicMock, patch
+
+    from sqlprism.core.graph import GraphDB
+    from sqlprism.core.indexer import Indexer
+
+    repo_dir = _build_minimal_dbt_project(
+        tmp_path / "proj",
+        compiled_models={
+            # A model that references the raw.customers source — gives the
+            # parser a table node the source column defs can attach to.
+            "staging/stg_customers.sql": 'SELECT id FROM "raw"."customers"',
+        },
+        manifest_nodes={
+            "model.my_proj.stg_customers": {
+                "resource_type": "model",
+                "package_name": "my_proj",
+                "name": "stg_customers",
+                "path": "staging/stg_customers.sql",
+                "depends_on": {"nodes": []},
+            },
+        },
+        schema_yml_sources=(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    tables:\n"
+            "      - name: customers\n"
+            "        columns:\n"
+            "          - name: id\n"
+            "            data_type: bigint\n"
+            "          - name: email\n"
+            "            data_type: varchar\n"
+        ),
+    )
+
+    db = GraphDB(":memory:")
+    indexer = Indexer(db)
+
+    with patch("sqlprism.languages.dbt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        indexer.reindex_dbt(
+            repo_name="proj", project_path=str(repo_dir), dialect="duckdb",
+        )
+
+    rows = db._execute_read(
+        "SELECT c.column_name, c.data_type, c.source "
+        "FROM columns c JOIN nodes n ON c.node_id = n.node_id "
+        "JOIN files f ON n.file_id = f.file_id "
+        "JOIN repos r ON f.repo_id = r.repo_id "
+        "WHERE r.name = ? AND n.name = ? "
+        "ORDER BY c.column_name",
+        ["proj", "customers"],
+    ).fetchall()
+
+    assert rows == [
+        ("email", "varchar", "schema_yml"),
+        ("id", "bigint", "schema_yml"),
+    ], rows
+
+    db.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -2766,15 +2766,9 @@ def test_reindex_sqlmesh_cross_repo_select_star_lineage_true_mesh(tmp_path):
         f"expected INT type to survive, got {catalog.get('stg_orders')}"
 
 
-@pytest.mark.xfail(
-    reason="Blocked by #125 — reindex_dbt never produces ColumnDefResult from "
-           "schema.yml / catalog.json, so upstream dbt types can't feed a "
-           "downstream sibling repo's schema catalog. Preserves the dbt-mesh "
-           "regression signal the original #124/#125 xfail carried.",
-    strict=True,
-)
 def test_reindex_dbt_cross_repo_select_star_lineage_true_mesh(tmp_path):
-    """True dbt→sqlmesh mesh — pinned as xfail until #125 persists dbt columns."""
+    """True dbt→sqlmesh mesh — upstream dbt column names reach the downstream
+    schema catalog, so SELECT * through a CTE expands and lineage resolves."""
     import json
     from unittest.mock import MagicMock, patch
 

--- a/tests/test_sql_parser.py
+++ b/tests/test_sql_parser.py
@@ -1760,6 +1760,9 @@ def test_parser_emits_column_defs_for_ctas_projection():
         f"unexpected columns: {orders}"
     assert all(c.source == "inferred" for c in orders), orders
     assert [c.position for c in orders] == [0, 1], orders
+    # Inferred rows carry names only — a regression that started emitting
+    # "TEXT" here would silently shadow better-typed schema.yml overrides.
+    assert [c.data_type for c in orders] == [None, None], orders
 
 
 def test_parser_ctas_inferred_columns_do_not_shadow_explicit_definition():

--- a/tests/test_sql_parser.py
+++ b/tests/test_sql_parser.py
@@ -1742,3 +1742,42 @@ def test_snowflake_dialect_normalize_file_stem():
     # File stem 'stg_orders' normalized to 'STG_ORDERS' should match the CREATE name
     file_nodes = [n for n in result.nodes if (n.metadata or {}).get("file_node")]
     assert len(file_nodes) == 0  # No file node because normalized names match
+
+
+def test_parser_emits_column_defs_for_ctas_projection():
+    """CREATE TABLE ... AS SELECT must emit ColumnDefResult entries mirroring
+    the projection order — dbt compiles every model through a CTAS wrap, so
+    without this the columns table stays empty for dbt-indexed projects."""
+    parser = SqlParser()
+    result = parser.parse(
+        "staging/orders.sql",
+        'CREATE TABLE "staging"."orders" AS '
+        "SELECT customer_id, order_id FROM raw.orders",
+    )
+
+    orders = [c for c in result.columns if c.node_name == "orders"]
+    assert [c.column_name for c in orders] == ["customer_id", "order_id"], \
+        f"unexpected columns: {orders}"
+    assert all(c.source == "inferred" for c in orders), orders
+    assert [c.position for c in orders] == [0, 1], orders
+
+
+def test_parser_ctas_inferred_columns_do_not_shadow_explicit_definition():
+    """Explicit schema-clause columns keep their `definition` entries;
+    inferred projection entries must dedup against them so a typed `a INT`
+    isn't overwritten by a name-only inferred duplicate."""
+    parser = SqlParser()
+    result = parser.parse(
+        "t.sql",
+        "CREATE TABLE t (a INT) AS SELECT a, b FROM src",
+    )
+
+    cols_for_t = [c for c in result.columns if c.node_name == "t"]
+    # `a` is defined, `b` is inferred — no double-entry for `a`.
+    a_rows = [c for c in cols_for_t if c.column_name == "a"]
+    assert len(a_rows) == 1, a_rows
+    assert a_rows[0].source == "definition"
+    assert a_rows[0].data_type == "INT"
+    b_rows = [c for c in cols_for_t if c.column_name == "b"]
+    assert len(b_rows) == 1, b_rows
+    assert b_rows[0].source == "inferred"


### PR DESCRIPTION
Closes #125

## Summary
- _to be updated on completion_

## Test Plan

| Scenario | Test | File | Status |
|----------|------|------|--------|
| CTAS projection populates columns | `test_parser_emits_column_defs_for_ctas_projection` | `tests/test_sql_parser.py` | pending |
| schema.yml column types land in graph | `test_reindex_dbt_persists_schema_yml_columns` | `tests/test_indexer.py` | pending |
| `get_table_columns` returns real types for dbt | `test_dbt_columns_visible_in_schema_catalog` | `tests/test_indexer.py` | pending |
| Sources in schema.yml captured | `test_reindex_dbt_captures_source_columns` | `tests/test_indexer.py` | pending |
| Non-dbt paths unchanged | existing suite | `tests/` | pending |