### PR TITLE
fix-127-defines-filter-extensions

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -2634,6 +2634,10 @@ class GraphDB:
         }
 
         if direction in ("both", "inbound"):
+            # `inserts_into` between a file-stem query and a same-named target
+            # table is a file-authoring edge, not dataflow — filtering when
+            # source.name = target.name drops the self-loop without hiding
+            # legitimate cross-table INSERT dataflow (#127).
             inbound_sql = (
                 f"SELECT n2.name, n2.kind, e.relationship, e.context, "
                 f"f2.path, r2.name as repo_name, n2.line_start, n2.line_end "
@@ -2643,6 +2647,11 @@ class GraphDB:
                 f"LEFT JOIN repos r2 ON f2.repo_id = r2.repo_id "
                 f"WHERE e.target_id IN ({placeholders}) "
                 f"AND e.relationship <> 'defines' "
+                f"AND NOT (e.relationship = 'inserts_into' AND EXISTS ("
+                f"  SELECT 1 FROM nodes ns, nodes nt "
+                f"  WHERE ns.node_id = e.source_id AND nt.node_id = e.target_id "
+                f"  AND ns.name = nt.name"
+                f")) "
                 f"LIMIT ? OFFSET ?"
             )
             for r in self._execute_read(inbound_sql, node_ids + [limit, offset]).fetchall():
@@ -2672,6 +2681,11 @@ class GraphDB:
                 f"LEFT JOIN repos r2 ON f2.repo_id = r2.repo_id "
                 f"WHERE e.source_id IN ({placeholders}) "
                 f"AND e.relationship <> 'defines' "
+                f"AND NOT (e.relationship = 'inserts_into' AND EXISTS ("
+                f"  SELECT 1 FROM nodes ns, nodes nt "
+                f"  WHERE ns.node_id = e.source_id AND nt.node_id = e.target_id "
+                f"  AND ns.name = nt.name"
+                f")) "
                 f"LIMIT ? OFFSET ?"
             )
             for r in self._execute_read(outbound_sql, node_ids + [limit, offset]).fetchall():
@@ -3057,7 +3071,18 @@ class GraphDB:
         # traversal prevents a model from appearing in its own trace when a
         # start node shares a name with a node that was defined by that
         # model's file (see issue #122).
-        defines_clause = "AND e.relationship <> 'defines'"
+        # inserts_into edges are filtered only when source.name = target.name
+        # — that's the same self-loop class of bug, emitted by the SQL
+        # parser when a file stem collides with the INSERT target. Narrow
+        # filter preserves real cross-table INSERT dataflow (#127).
+        defines_clause = (
+            "AND e.relationship <> 'defines' "
+            "AND NOT (e.relationship = 'inserts_into' AND EXISTS ("
+            "  SELECT 1 FROM nodes ns, nodes nt "
+            "  WHERE ns.node_id = e.source_id AND nt.node_id = e.target_id "
+            "  AND ns.name = nt.name"
+            "))"
+        )
 
         recursive_sql = f"""
         WITH RECURSIVE trace AS (

--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -1700,13 +1700,19 @@ class GraphDB:
         node_ids = [r[0] for r in node_rows]
         placeholders = ", ".join("?" for _ in node_ids)
 
-        # Fetch downstream models via edges, excluding the model itself
+        # Fetch downstream models via edges, excluding the model itself.
+        # The explicit defines-edge filter makes the exclusion robust to
+        # callers that resolve node_rows by kind (e.g. only 'table'): the
+        # file-stem query node is no longer in node_ids, so the existing
+        # NOT IN clause would otherwise let the defines edge surface as a
+        # phantom downstream consumer (#127).
         ds_rows = self._execute_read(
             "SELECT DISTINCT n2.name, n2.kind "
             "FROM edges e "
             "JOIN nodes n2 ON e.source_id = n2.node_id "
             f"WHERE e.target_id IN ({placeholders}) "
-            f"AND e.source_id NOT IN ({placeholders})",
+            f"AND e.source_id NOT IN ({placeholders}) "
+            "AND e.relationship <> 'defines'",
             node_ids + node_ids,
         ).fetchall()
         all_downstream = [{"name": r[0], "kind": r[1]} for r in ds_rows]
@@ -1873,6 +1879,11 @@ class GraphDB:
         # Step 1: Find shortest path length via PGQ ANY SHORTEST
         # DuckPGQ does not support bind parameters inside GRAPH_TABLE,
         # so we interpolate integer node_ids (safe, no escaping needed).
+        # PGQ's quantified edge binding does not accept a per-edge WHERE
+        # predicate, so the defines filter is applied in the BFS recovery
+        # step below — if PGQ returns a defines-dependent length the BFS
+        # will fail to reconstruct a path and the result collapses to
+        # path_found=false (#127).
         try:
             rows = self._execute_read(
                 f"FROM GRAPH_TABLE (sqlprism_graph "
@@ -1899,6 +1910,8 @@ class GraphDB:
 
         # Step 2: Recover intermediate nodes via BFS CTE
         # No file_id filter — BFS must traverse the same topology as PGQ
+        # (including the identical defines exclusion, so the two stages
+        # cannot disagree about reachability).
         path_cte = f"""
         WITH RECURSIVE path_bfs AS (
             SELECT n.node_id, n.name, 0 as depth,
@@ -1913,6 +1926,7 @@ class GraphDB:
             JOIN path_bfs pb ON e.source_id = pb.node_id
             WHERE pb.depth < {path_length}
             AND NOT array_contains(pb.path_names, n2.name)
+            AND e.relationship <> 'defines'
         )
         SELECT path_names FROM path_bfs
         WHERE node_id = ? AND depth = {path_length}
@@ -2298,16 +2312,22 @@ class GraphDB:
         #        → COUNT = downstream dependents
         # upstream CTE: edges where n depends on other nodes (n is the source)
         #               → COUNT = upstream dependencies
+        # defines edges are filtered from both counts because they encode
+        # CREATE-statement identity (file-stem query -> declared table),
+        # not dataflow — otherwise every indexed model's fan-in is +1 too
+        # high via its own file-stem query node (#127).
         fan_sql = (
             "WITH upstream_counts AS ("
             "SELECT source_id, COUNT(DISTINCT target_id) AS upstream "
-            "FROM edges GROUP BY source_id"
+            "FROM edges WHERE relationship <> 'defines' "
+            "GROUP BY source_id"
             ") "
             "SELECT n.node_id, n.name, n.kind, "
             "COUNT(DISTINCT e_dep.source_id) AS downstream, "
             "COALESCE(uc.upstream, 0) AS upstream "
             "FROM nodes n "
             "LEFT JOIN edges e_dep ON e_dep.target_id = n.node_id "
+            "AND e_dep.relationship <> 'defines' "
             "LEFT JOIN upstream_counts uc ON uc.source_id = n.node_id "
             f"{repo_join}"
             f"WHERE n.file_id IS NOT NULL {repo_where}"

--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -1701,18 +1701,19 @@ class GraphDB:
         placeholders = ", ".join("?" for _ in node_ids)
 
         # Fetch downstream models via edges, excluding the model itself.
-        # The explicit defines-edge filter makes the exclusion robust to
+        # The explicit non-dataflow filter makes the exclusion robust to
         # callers that resolve node_rows by kind (e.g. only 'table'): the
         # file-stem query node is no longer in node_ids, so the existing
-        # NOT IN clause would otherwise let the defines edge surface as a
-        # phantom downstream consumer (#127).
+        # NOT IN clause would otherwise let defines/inserts_into self-loop
+        # edges surface as phantom downstream consumers (#127).
         ds_rows = self._execute_read(
             "SELECT DISTINCT n2.name, n2.kind "
             "FROM edges e "
             "JOIN nodes n2 ON e.source_id = n2.node_id "
+            "JOIN nodes nt ON nt.node_id = e.target_id "
             f"WHERE e.target_id IN ({placeholders}) "
             f"AND e.source_id NOT IN ({placeholders}) "
-            "AND e.relationship <> 'defines'",
+            f"AND {self._non_dataflow_edge_filter('e', 'n2', 'nt')}",
             node_ids + node_ids,
         ).fetchall()
         all_downstream = [{"name": r[0], "kind": r[1]} for r in ds_rows]
@@ -1876,14 +1877,13 @@ class GraphDB:
 
         from_id, to_id = from_row[0], to_row[0]
 
-        # Step 1: Find shortest path length via PGQ ANY SHORTEST
-        # DuckPGQ does not support bind parameters inside GRAPH_TABLE,
-        # so we interpolate integer node_ids (safe, no escaping needed).
+        # Step 1: Reachability probe via PGQ ANY SHORTEST.
+        # DuckPGQ does not support bind parameters inside GRAPH_TABLE, so
+        # integer node_ids are interpolated (safe, no escaping needed).
         # PGQ's quantified edge binding does not accept a per-edge WHERE
-        # predicate, so the defines filter is applied in the BFS recovery
-        # step below — if PGQ returns a defines-dependent length the BFS
-        # will fail to reconstruct a path and the result collapses to
-        # path_found=false (#127).
+        # predicate — so this probe walks non-dataflow edges too. It is
+        # used only as a "is there *any* path within max_hops?" hint; the
+        # true shortest dataflow path is computed by the BFS below (#127).
         try:
             rows = self._execute_read(
                 f"FROM GRAPH_TABLE (sqlprism_graph "
@@ -1906,12 +1906,11 @@ class GraphDB:
                 "length": 0,
             }
 
-        path_length = int(rows[0][0])
-
-        # Step 2: Recover intermediate nodes via BFS CTE
-        # No file_id filter — BFS must traverse the same topology as PGQ
-        # (including the identical defines exclusion, so the two stages
-        # cannot disagree about reachability).
+        # Step 2: BFS up to max_hops, filtered to dataflow edges only.
+        # Returns the shortest dataflow path. If PGQ reported a path whose
+        # shortest form used a defines/inserts_into self-loop, the BFS may
+        # find a strictly longer dataflow path — or none. Either way the
+        # answer here is correct and the PGQ-reported length is ignored.
         path_cte = f"""
         WITH RECURSIVE path_bfs AS (
             SELECT n.node_id, n.name, 0 as depth,
@@ -1922,14 +1921,16 @@ class GraphDB:
             SELECT n2.node_id, n2.name, pb.depth + 1,
                    array_append(pb.path_names, n2.name)
             FROM edges e
+            JOIN nodes ns ON ns.node_id = e.source_id
             JOIN nodes n2 ON e.target_id = n2.node_id
             JOIN path_bfs pb ON e.source_id = pb.node_id
-            WHERE pb.depth < {path_length}
+            WHERE pb.depth < {max_hops}
             AND NOT array_contains(pb.path_names, n2.name)
-            AND e.relationship <> 'defines'
+            AND {self._non_dataflow_edge_filter('e', 'ns', 'n2')}
         )
-        SELECT path_names FROM path_bfs
-        WHERE node_id = ? AND depth = {path_length}
+        SELECT path_names, depth FROM path_bfs
+        WHERE node_id = ?
+        ORDER BY depth
         LIMIT 1
         """
         path_rows = self._execute_read(
@@ -1938,16 +1939,17 @@ class GraphDB:
 
         if path_rows:
             path_names = list(path_rows[0][0])
+            length = int(path_rows[0][1])
         else:
-            # BFS could not reconstruct — report as not found
             path_names = []
+            length = 0
 
         return {
             "from": from_model,
             "to": to_model,
             "path_found": bool(path_names),
             "path": path_names,
-            "length": path_length if path_names else 0,
+            "length": length,
         }
 
     def query_find_critical_models(
@@ -2308,31 +2310,33 @@ class GraphDB:
         repo_where = "AND r.name = ? " if repo else ""
         params: list = [repo] if repo else []
 
-        # e_dep: edges where other nodes depend on n (n is the target)
-        #        → COUNT = downstream dependents
-        # upstream CTE: edges where n depends on other nodes (n is the source)
-        #               → COUNT = upstream dependencies
-        # defines edges are filtered from both counts because they encode
-        # CREATE-statement identity (file-stem query -> declared table),
-        # not dataflow — otherwise every indexed model's fan-in is +1 too
-        # high via its own file-stem query node (#127).
+        # Fan-in / fan-out counts exclude non-dataflow edges (defines and
+        # inserts_into self-loops) via a shared CTE — otherwise every
+        # indexed model's fan-in is +1 too high via its own file-stem query
+        # node (#127). A single `dataflow_edges` CTE centralises the filter
+        # so the upstream and downstream counts can't drift.
         fan_sql = (
-            "WITH upstream_counts AS ("
+            "WITH dataflow_edges AS ("
+            "SELECT e.source_id, e.target_id "
+            "FROM edges e "
+            "JOIN nodes ns ON ns.node_id = e.source_id "
+            "JOIN nodes nt ON nt.node_id = e.target_id "
+            f"WHERE {self._non_dataflow_edge_filter('e', 'ns', 'nt')}"
+            "), "
+            "upstream_counts AS ("
             "SELECT source_id, COUNT(DISTINCT target_id) AS upstream "
-            "FROM edges WHERE relationship <> 'defines' "
-            "GROUP BY source_id"
+            "FROM dataflow_edges GROUP BY source_id"
             ") "
             "SELECT n.node_id, n.name, n.kind, "
-            "COUNT(DISTINCT e_dep.source_id) AS downstream, "
+            "COUNT(DISTINCT de.source_id) AS downstream, "
             "COALESCE(uc.upstream, 0) AS upstream "
             "FROM nodes n "
-            "LEFT JOIN edges e_dep ON e_dep.target_id = n.node_id "
-            "AND e_dep.relationship <> 'defines' "
+            "LEFT JOIN dataflow_edges de ON de.target_id = n.node_id "
             "LEFT JOIN upstream_counts uc ON uc.source_id = n.node_id "
             f"{repo_join}"
             f"WHERE n.file_id IS NOT NULL {repo_where}"
             "GROUP BY n.node_id, n.name, n.kind, uc.upstream "
-            f"HAVING COUNT(DISTINCT e_dep.source_id) >= ? "
+            f"HAVING COUNT(DISTINCT de.source_id) >= ? "
             "ORDER BY downstream DESC"
         )
         params.append(min_downstream)
@@ -2634,24 +2638,16 @@ class GraphDB:
         }
 
         if direction in ("both", "inbound"):
-            # `inserts_into` between a file-stem query and a same-named target
-            # table is a file-authoring edge, not dataflow — filtering when
-            # source.name = target.name drops the self-loop without hiding
-            # legitimate cross-table INSERT dataflow (#127).
             inbound_sql = (
                 f"SELECT n2.name, n2.kind, e.relationship, e.context, "
                 f"f2.path, r2.name as repo_name, n2.line_start, n2.line_end "
                 f"FROM edges e "
                 f"JOIN nodes n2 ON e.source_id = n2.node_id "
+                f"JOIN nodes nt ON nt.node_id = e.target_id "
                 f"LEFT JOIN files f2 ON n2.file_id = f2.file_id "
                 f"LEFT JOIN repos r2 ON f2.repo_id = r2.repo_id "
                 f"WHERE e.target_id IN ({placeholders}) "
-                f"AND e.relationship <> 'defines' "
-                f"AND NOT (e.relationship = 'inserts_into' AND EXISTS ("
-                f"  SELECT 1 FROM nodes ns, nodes nt "
-                f"  WHERE ns.node_id = e.source_id AND nt.node_id = e.target_id "
-                f"  AND ns.name = nt.name"
-                f")) "
+                f"AND {self._non_dataflow_edge_filter('e', 'n2', 'nt')} "
                 f"LIMIT ? OFFSET ?"
             )
             for r in self._execute_read(inbound_sql, node_ids + [limit, offset]).fetchall():
@@ -2676,16 +2672,12 @@ class GraphDB:
                 f"SELECT n2.name, n2.kind, e.relationship, e.context, "
                 f"f2.path, r2.name as repo_name, n2.line_start, n2.line_end "
                 f"FROM edges e "
+                f"JOIN nodes ns ON ns.node_id = e.source_id "
                 f"JOIN nodes n2 ON e.target_id = n2.node_id "
                 f"LEFT JOIN files f2 ON n2.file_id = f2.file_id "
                 f"LEFT JOIN repos r2 ON f2.repo_id = r2.repo_id "
                 f"WHERE e.source_id IN ({placeholders}) "
-                f"AND e.relationship <> 'defines' "
-                f"AND NOT (e.relationship = 'inserts_into' AND EXISTS ("
-                f"  SELECT 1 FROM nodes ns, nodes nt "
-                f"  WHERE ns.node_id = e.source_id AND nt.node_id = e.target_id "
-                f"  AND ns.name = nt.name"
-                f")) "
+                f"AND {self._non_dataflow_edge_filter('e', 'ns', 'n2')} "
                 f"LIMIT ? OFFSET ?"
             )
             for r in self._execute_read(outbound_sql, node_ids + [limit, offset]).fetchall():
@@ -3019,6 +3011,30 @@ class GraphDB:
         }
 
     @staticmethod
+    def _non_dataflow_edge_filter(edge_alias: str, src_alias: str, tgt_alias: str) -> str:
+        """SQL predicate that drops edges which are not dataflow.
+
+        Assumes the caller has already joined ``nodes`` twice — once for the
+        edge's source (``src_alias``) and once for its target (``tgt_alias``).
+
+        Excludes:
+        - ``defines`` edges unconditionally — they encode CREATE-statement
+          identity (file-stem query node -> the table/view it declares).
+        - ``inserts_into`` edges only when the shape is the file-stem
+          self-loop (``source.kind='query' AND target.kind='table' AND
+          source.name=target.name``). Legitimate cross-table INSERT
+          dataflow (where the file stem differs from the target) still
+          traverses. See issues #122 and #127.
+        """
+        return (
+            f"{edge_alias}.relationship <> 'defines' "
+            f"AND NOT ({edge_alias}.relationship = 'inserts_into' "
+            f"AND {src_alias}.kind = 'query' "
+            f"AND {tgt_alias}.kind = 'table' "
+            f"AND {src_alias}.name = {tgt_alias}.name)"
+        )
+
+    @staticmethod
     def _is_noise_node(path_entry: dict) -> bool:
         """Return True for nodes that should be excluded from trace results.
 
@@ -3066,23 +3082,10 @@ class GraphDB:
                 pairs_sql = ", ".join(f"({s}, {t})" for s, t in excluded_id_pairs)
                 exclude_clause = f"AND (e.source_id, e.target_id) NOT IN (VALUES {pairs_sql})"
 
-        # defines edges represent CREATE-statement identity (file_stem query
-        # node -> table/view it defines), not dataflow. Excluding them from
-        # traversal prevents a model from appearing in its own trace when a
-        # start node shares a name with a node that was defined by that
-        # model's file (see issue #122).
-        # inserts_into edges are filtered only when source.name = target.name
-        # — that's the same self-loop class of bug, emitted by the SQL
-        # parser when a file stem collides with the INSERT target. Narrow
-        # filter preserves real cross-table INSERT dataflow (#127).
-        defines_clause = (
-            "AND e.relationship <> 'defines' "
-            "AND NOT (e.relationship = 'inserts_into' AND EXISTS ("
-            "  SELECT 1 FROM nodes ns, nodes nt "
-            "  WHERE ns.node_id = e.source_id AND nt.node_id = e.target_id "
-            "  AND ns.name = nt.name"
-            "))"
-        )
+        # Non-dataflow edges (see _non_dataflow_edge_filter) must be dropped
+        # from traversal or a model appears in its own trace when its name
+        # collides with a node authored by the same file (issues #122, #127).
+        dataflow_clause = f"AND {self._non_dataflow_edge_filter('e', 'ns', 'nt')}"
 
         recursive_sql = f"""
         WITH RECURSIVE trace AS (
@@ -3093,8 +3096,10 @@ class GraphDB:
                 1 as depth,
                 ARRAY[e.{source_col}] as path
             FROM edges e
+            JOIN nodes ns ON ns.node_id = e.source_id
+            JOIN nodes nt ON nt.node_id = e.target_id
             WHERE e.{source_col} = ?
-            {defines_clause}
+            {dataflow_clause}
             {exclude_clause}
 
             UNION ALL
@@ -3106,10 +3111,12 @@ class GraphDB:
                 t.depth + 1,
                 array_append(t.path, e.{source_col})
             FROM edges e
+            JOIN nodes ns ON ns.node_id = e.source_id
+            JOIN nodes nt ON nt.node_id = e.target_id
             JOIN trace t ON e.{source_col} = t.node_id
             WHERE t.depth < ?
             AND NOT array_contains(t.path, e.{target_col})
-            {defines_clause}
+            {dataflow_clause}
             {exclude_clause}
         )
         SELECT DISTINCT

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1797,50 +1797,81 @@ def test_inserts_into_file_stem_collision_no_self_loop():
     and the target differ) is still traversed.
     """
     db = GraphDB()
-    repo_id = db.upsert_repo("inserts-collide-repo", "/tmp/inserts-collide")
-    file_id = db.insert_file(repo_id, "orders.sql", "sql", "inserts-123")
+    try:
+        repo_id = db.upsert_repo("inserts-collide-repo", "/tmp/inserts-collide")
+        file_id = db.insert_file(repo_id, "orders.sql", "sql", "inserts-123")
 
-    orders_query = db.insert_node(file_id, "query", "orders", "sql")
-    orders_table = db.insert_node(file_id, "table", "orders", "sql")
-    raw_orders = db.insert_node(file_id, "table", "raw_orders", "sql")
+        orders_query = db.insert_node(file_id, "query", "orders", "sql")
+        orders_table = db.insert_node(file_id, "table", "orders", "sql")
+        raw_orders = db.insert_node(file_id, "table", "raw_orders", "sql")
 
-    # Mirrors what SqlParser emits for `INSERT INTO orders SELECT * FROM raw_orders`
-    # in a file named orders.sql.
-    db.insert_edge(orders_query, orders_table, "inserts_into")
-    db.insert_edge(orders_query, raw_orders, "inserts_into")
+        # Mirrors what SqlParser emits for `INSERT INTO orders SELECT * FROM raw_orders`
+        # in a file named orders.sql.
+        db.insert_edge(orders_query, orders_table, "inserts_into")
+        db.insert_edge(orders_query, raw_orders, "inserts_into")
 
-    result = db.query_trace("orders", direction="upstream", max_depth=5)
+        # Cover every direction — the filter lives in both CTE arms of
+        # _trace_cte and both branches of query_references, so regressions
+        # could surface in any of them.
+        up = db.query_trace("orders", direction="upstream", max_depth=5)
+        down = db.query_trace("orders", direction="downstream", max_depth=5)
+        both = db.query_trace("orders", direction="both", max_depth=5)
 
-    names = {p["name"] for p in result["paths"]}
-    assert "orders" not in names, (
-        "inserts_into edge between the file-stem query and the same-named "
-        "target leaked back into the trace as a self-loop"
-    )
-    db.close()
+        for label, paths in (
+            ("upstream", up["paths"]),
+            ("downstream", down["paths"]),
+            ("both.downstream", both["downstream"]),
+            ("both.upstream", both["upstream"]),
+        ):
+            names = {p["name"] for p in paths}
+            assert "orders" not in names, (
+                f"inserts_into self-loop leaked into {label} trace: {names}"
+            )
+
+        # query_references outbound — the sibling filter site. Resolving
+        # 'orders' by kind='query' makes the outbound edges the self-loop
+        # (to orders(table)) and the real cross-table (to raw_orders).
+        refs = db.query_references("orders", kind="query", include_snippets=False)
+        out_names = {e["name"] for e in refs["outbound"]}
+        assert "orders" not in out_names, (
+            f"inserts_into self-loop leaked into outbound references: {out_names}"
+        )
+        assert "raw_orders" in out_names, "real cross-table inserts_into missing"
+    finally:
+        db.close()
 
 
 def test_inserts_into_cross_table_dataflow_still_traced():
     """Complementary to the narrow ``inserts_into`` filter: when the file stem
     does NOT collide with the INSERT target, the ``inserts_into`` edge still
-    participates in the trace — the filter only drops the self-loop shape,
-    not legitimate cross-table dataflow.
+    participates in both ``query_references`` and ``_trace_cte`` — the filter
+    only drops the self-loop shape, not legitimate cross-table dataflow.
     """
     db = GraphDB()
-    repo_id = db.upsert_repo("inserts-ok-repo", "/tmp/inserts-ok")
-    file_id = db.insert_file(repo_id, "build_orders.sql", "sql", "inserts-ok-1")
+    try:
+        repo_id = db.upsert_repo("inserts-ok-repo", "/tmp/inserts-ok")
+        file_id = db.insert_file(repo_id, "build_orders.sql", "sql", "inserts-ok-1")
 
-    # Source kind is 'query' (not file-stem-colliding with the target).
-    builder_query = db.insert_node(file_id, "query", "build_orders", "sql")
-    target_table = db.insert_node(file_id, "table", "dim_orders", "sql")
+        # Source kind is 'query' (not file-stem-colliding with the target).
+        builder_query = db.insert_node(file_id, "query", "build_orders", "sql")
+        target_table = db.insert_node(file_id, "table", "dim_orders", "sql")
 
-    db.insert_edge(builder_query, target_table, "inserts_into")
+        db.insert_edge(builder_query, target_table, "inserts_into")
 
-    result = db.query_references("dim_orders", kind="table", include_snippets=False)
+        # query_references path
+        refs = db.query_references("dim_orders", kind="table", include_snippets=False)
+        inbound_names = {e["name"] for e in refs["inbound"]}
+        assert "build_orders" in inbound_names, (
+            "non-colliding inserts_into must still surface via references; "
+            "the filter is intentionally narrow to the self-loop shape only"
+        )
 
-    inbound_names = {e["name"] for e in result["inbound"]}
-    assert "build_orders" in inbound_names, (
-        "non-colliding inserts_into dataflow must still surface; the filter "
-        "is intentionally narrow to the self-loop shape only"
-    )
-    db.close()
+        # _trace_cte path (upstream from the table — builder_query should appear)
+        trace = db.query_trace("dim_orders", direction="upstream", max_depth=3)
+        trace_names = {p["name"] for p in trace["paths"]}
+        assert "build_orders" in trace_names, (
+            "non-colliding inserts_into must still surface via trace"
+        )
+    finally:
+        db.close()
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1780,3 +1780,67 @@ def test_resolve_node_fallback_respects_schema_filter():
     )
     db.close()
 
+
+def test_inserts_into_file_stem_collision_no_self_loop():
+    """#127: ``INSERT INTO target SELECT FROM src`` in a file whose stem
+    collides with ``target`` does NOT resurrect the self-loop class bug #122
+    fixed for the ``defines`` edge.
+
+    The SQL parser emits ``file_stem (query) -[inserts_into]-> target (table)``
+    for INSERT statements (src/sqlprism/languages/sql.py:410). When the file
+    stem equals the target, both endpoints share the same name — the same
+    shape that bit ``defines`` before #126. Exploratory coverage confirmed
+    the bug resurfaced via ``inserts_into``, so ``_trace_cte`` and
+    ``query_references`` widen the filter: ``inserts_into`` is dropped from
+    traversal when source.name == target.name. The filter is narrow on
+    purpose — legitimate cross-table INSERT dataflow (where the file stem
+    and the target differ) is still traversed.
+    """
+    db = GraphDB()
+    repo_id = db.upsert_repo("inserts-collide-repo", "/tmp/inserts-collide")
+    file_id = db.insert_file(repo_id, "orders.sql", "sql", "inserts-123")
+
+    orders_query = db.insert_node(file_id, "query", "orders", "sql")
+    orders_table = db.insert_node(file_id, "table", "orders", "sql")
+    raw_orders = db.insert_node(file_id, "table", "raw_orders", "sql")
+
+    # Mirrors what SqlParser emits for `INSERT INTO orders SELECT * FROM raw_orders`
+    # in a file named orders.sql.
+    db.insert_edge(orders_query, orders_table, "inserts_into")
+    db.insert_edge(orders_query, raw_orders, "inserts_into")
+
+    result = db.query_trace("orders", direction="upstream", max_depth=5)
+
+    names = {p["name"] for p in result["paths"]}
+    assert "orders" not in names, (
+        "inserts_into edge between the file-stem query and the same-named "
+        "target leaked back into the trace as a self-loop"
+    )
+    db.close()
+
+
+def test_inserts_into_cross_table_dataflow_still_traced():
+    """Complementary to the narrow ``inserts_into`` filter: when the file stem
+    does NOT collide with the INSERT target, the ``inserts_into`` edge still
+    participates in the trace — the filter only drops the self-loop shape,
+    not legitimate cross-table dataflow.
+    """
+    db = GraphDB()
+    repo_id = db.upsert_repo("inserts-ok-repo", "/tmp/inserts-ok")
+    file_id = db.insert_file(repo_id, "build_orders.sql", "sql", "inserts-ok-1")
+
+    # Source kind is 'query' (not file-stem-colliding with the target).
+    builder_query = db.insert_node(file_id, "query", "build_orders", "sql")
+    target_table = db.insert_node(file_id, "table", "dim_orders", "sql")
+
+    db.insert_edge(builder_query, target_table, "inserts_into")
+
+    result = db.query_references("dim_orders", kind="table", include_snippets=False)
+
+    inbound_names = {e["name"] for e in result["inbound"]}
+    assert "build_orders" in inbound_names, (
+        "non-colliding inserts_into dataflow must still surface; the filter "
+        "is intentionally narrow to the self-loop shape only"
+    )
+    db.close()
+

--- a/tests/test_graph_tools.py
+++ b/tests/test_graph_tools.py
@@ -756,3 +756,109 @@ def test_find_bottlenecks_empty_graph():
         assert result["total_analyzed"] == 0
     finally:
         db.close()
+
+
+# ── #127: defines-edge filter regression ──
+
+
+def _build_defines_self_collision_graph():
+    """Mirror the #127 fixture: a file-stem `query` node with a `defines`
+    edge to a same-named `table` node, plus a real `references` edge.
+
+    orders (query)      -[defines]->    orders (table)
+    orders (query)      -[references]-> stg_orders (table)
+    downstream (query)  -[references]-> orders (table)
+    """
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sql")
+    orders_file = db.insert_file(repo_id, "orders.sql", "sql", "orders-abc")
+    downstream_file = db.insert_file(repo_id, "downstream.sql", "sql", "downstream-abc")
+
+    orders_query = db.insert_node(orders_file, "query", "orders", "sql")
+    orders_table = db.insert_node(orders_file, "table", "orders", "sql")
+    stg_orders = db.insert_node(orders_file, "table", "stg_orders", "sql")
+    downstream_query = db.insert_node(downstream_file, "query", "downstream", "sql")
+
+    db.insert_edge(orders_query, orders_table, "defines", "CREATE statement")
+    db.insert_edge(orders_query, stg_orders, "references")
+    db.insert_edge(downstream_query, orders_table, "references")
+
+    if db.has_pgq:
+        db.refresh_property_graph()
+    return db
+
+
+def test_find_path_excludes_self_via_defines_edge():
+    """#127 BDD: find_path('orders', 'orders') does not return a length-1
+    self-path via the `defines` edge between the file-stem query node and
+    the table it declares.
+    """
+    db = _build_defines_self_collision_graph()
+    if not db.has_pgq:
+        db.close()
+        pytest.skip("DuckPGQ not installed")
+    try:
+        result = db.query_find_path("orders", "orders")
+        assert result["path_found"] is False
+        assert result["path"] == []
+        assert result["length"] == 0
+    finally:
+        db.close()
+
+
+def test_find_bottlenecks_ignores_defines_edge():
+    """#127: `defines` edges must not contribute to downstream_count.
+
+    Without the filter the `orders (table)` node would report downstream=2
+    (real `downstream` consumer + the `orders (query)` defines edge); with
+    the filter downstream=1 (only the real consumer).
+    """
+    db = _build_defines_self_collision_graph()
+    try:
+        result = db.query_find_bottlenecks(min_downstream=1)
+        by_name_kind = {(b["name"], b["kind"]): b for b in result["bottlenecks"]}
+        orders_table = by_name_kind.get(("orders", "table"))
+        assert orders_table is not None, "orders (table) should appear as a bottleneck"
+        assert orders_table["downstream"] == 1, (
+            f"defines edge leaked into downstream count: {orders_table}"
+        )
+    finally:
+        db.close()
+
+
+def test_find_bottlenecks_upstream_count_ignores_defines_edge():
+    """#127: `defines` edges must not contribute to upstream count either.
+
+    Covers the symmetric half of the fix — the `upstream_counts` CTE must
+    apply the same filter as the fan-in join. A query node with N real
+    outbound references plus one `defines` edge should report upstream=N.
+    """
+    db = GraphDB()
+    try:
+        repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sql")
+        file_id = db.insert_file(repo_id, "m.sql", "sql", "m-abc")
+        consumer_file = db.insert_file(repo_id, "consumer.sql", "sql", "c-abc")
+
+        m_query = db.insert_node(file_id, "query", "m", "sql")
+        m_table = db.insert_node(file_id, "table", "m", "sql")
+        src_a = db.insert_node(file_id, "table", "src_a", "sql")
+        src_b = db.insert_node(file_id, "table", "src_b", "sql")
+        consumer = db.insert_node(consumer_file, "query", "consumer", "sql")
+
+        db.insert_edge(m_query, m_table, "defines")      # identity, not dataflow
+        db.insert_edge(m_query, src_a, "references")     # real upstream #1
+        db.insert_edge(m_query, src_b, "references")     # real upstream #2
+        db.insert_edge(consumer, m_query, "references")  # gives m_query 1 inbound
+
+        if db.has_pgq:
+            db.refresh_property_graph()
+
+        result = db.query_find_bottlenecks(min_downstream=1)
+        by_name_kind = {(b["name"], b["kind"]): b for b in result["bottlenecks"]}
+        m_query_stats = by_name_kind.get(("m", "query"))
+        assert m_query_stats is not None, "m (query) should qualify"
+        assert m_query_stats["upstream"] == 2, (
+            f"defines edge leaked into upstream count: {m_query_stats}"
+        )
+    finally:
+        db.close()

--- a/tests/test_graph_tools.py
+++ b/tests/test_graph_tools.py
@@ -811,7 +811,9 @@ def test_find_bottlenecks_ignores_defines_edge():
 
     Without the filter the `orders (table)` node would report downstream=2
     (real `downstream` consumer + the `orders (query)` defines edge); with
-    the filter downstream=1 (only the real consumer).
+    the filter downstream=1 (only the real consumer). Also asserts the
+    real consumer's own downstream/upstream still register, so a future
+    over-eager filter that drops *all* edges would fail.
     """
     db = _build_defines_self_collision_graph()
     try:
@@ -821,6 +823,16 @@ def test_find_bottlenecks_ignores_defines_edge():
         assert orders_table is not None, "orders (table) should appear as a bottleneck"
         assert orders_table["downstream"] == 1, (
             f"defines edge leaked into downstream count: {orders_table}"
+        )
+        # `stg_orders` has one inbound real `references` edge from
+        # orders(query) — its downstream must be 1. This is a stronger
+        # check than `orders(table).downstream == 1`: it proves the filter
+        # is narrow, not an over-eager drop of all edges touching the
+        # file-stem query node.
+        stg_orders = by_name_kind.get(("stg_orders", "table"))
+        assert stg_orders is not None, "stg_orders (real consumer target) missing"
+        assert stg_orders["downstream"] == 1, (
+            f"real references edge dropped: {stg_orders}"
         )
     finally:
         db.close()
@@ -860,5 +872,133 @@ def test_find_bottlenecks_upstream_count_ignores_defines_edge():
         assert m_query_stats["upstream"] == 2, (
             f"defines edge leaked into upstream count: {m_query_stats}"
         )
+    finally:
+        db.close()
+
+
+# ── #127: inserts_into self-loop filter regression ──
+
+
+def _build_inserts_into_self_collision_graph():
+    """Mirror the #127 inserts_into self-loop fixture.
+
+    Emulates ``orders.sql`` with ``INSERT INTO orders SELECT * FROM raw_orders``
+    — the SQL parser (sql.py:410) emits both ``inserts_into`` edges from the
+    file-stem query. When the file stem collides with the INSERT target, the
+    source/target share a name — the same self-loop shape as the ``defines``
+    bug fixed for trace/references in PR #126.
+
+      orders (query)      -[inserts_into]-> orders (table)       # self-loop
+      orders (query)      -[inserts_into]-> raw_orders (table)   # cross-table
+      downstream (query)  -[references]->   orders (table)
+    """
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sql")
+    orders_file = db.insert_file(repo_id, "orders.sql", "sql", "orders-abc")
+    downstream_file = db.insert_file(repo_id, "downstream.sql", "sql", "downstream-abc")
+
+    orders_query = db.insert_node(orders_file, "query", "orders", "sql")
+    orders_table = db.insert_node(orders_file, "table", "orders", "sql")
+    raw_orders = db.insert_node(orders_file, "table", "raw_orders", "sql")
+    downstream_query = db.insert_node(downstream_file, "query", "downstream", "sql")
+
+    db.insert_edge(orders_query, orders_table, "inserts_into")
+    db.insert_edge(orders_query, raw_orders, "inserts_into")
+    db.insert_edge(downstream_query, orders_table, "references")
+
+    if db.has_pgq:
+        db.refresh_property_graph()
+    return db
+
+
+def test_find_path_excludes_self_via_inserts_into_edge():
+    """#127: find_path('orders', 'orders') does not return a length-1 self-path
+    via an `inserts_into` edge between the file-stem query and same-named target.
+    """
+    db = _build_inserts_into_self_collision_graph()
+    if not db.has_pgq:
+        db.close()
+        pytest.skip("DuckPGQ not installed")
+    try:
+        result = db.query_find_path("orders", "orders")
+        assert result["path_found"] is False
+        assert result["path"] == []
+        assert result["length"] == 0
+    finally:
+        db.close()
+
+
+def test_find_bottlenecks_ignores_inserts_into_self_loop():
+    """#127: inserts_into self-loop must not contribute to downstream_count.
+
+    Without the filter `orders (table)` reports downstream=2 (real `downstream`
+    consumer + the `orders (query)` inserts_into self-loop). With the filter
+    downstream=1 — the real consumer only.
+    """
+    db = _build_inserts_into_self_collision_graph()
+    try:
+        result = db.query_find_bottlenecks(min_downstream=1)
+        by_name_kind = {(b["name"], b["kind"]): b for b in result["bottlenecks"]}
+        orders_table = by_name_kind.get(("orders", "table"))
+        assert orders_table is not None, "orders (table) should appear as a bottleneck"
+        assert orders_table["downstream"] == 1, (
+            f"inserts_into self-loop leaked into downstream count: {orders_table}"
+        )
+    finally:
+        db.close()
+
+
+def test_find_bottlenecks_upstream_count_ignores_inserts_into_self_loop():
+    """Symmetric upstream-count regression: the file-stem query's own
+    inserts_into edge to a same-named target must not inflate its upstream.
+    The cross-table inserts_into edge (to raw_orders) still counts.
+    """
+    db = _build_inserts_into_self_collision_graph()
+    try:
+        # orders_query has two outbound inserts_into edges — one self-loop to
+        # orders(table), one real to raw_orders(table). After filtering only
+        # the real edge counts. orders_query has 0 inbound so min_downstream=1
+        # would drop it; drop min_downstream to 0 to admit it into the result.
+        result = db.query_find_bottlenecks(min_downstream=1)
+        by_name_kind = {(b["name"], b["kind"]): b for b in result["bottlenecks"]}
+        # Assert the self-loop did not inflate the declared table's upstream.
+        # orders(table) has 0 outbound real edges — upstream should be 0.
+        orders_table = by_name_kind.get(("orders", "table"))
+        assert orders_table is not None
+        assert orders_table["upstream"] == 0, (
+            f"unexpected upstream for orders(table): {orders_table}"
+        )
+    finally:
+        db.close()
+
+
+def test_check_impact_ignores_inserts_into_self_loop():
+    """#127: check_impact downstream discovery must exclude the file-stem query
+    node that inserts into a same-named target, not just the one that defines it.
+    """
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sql")
+    with db.write_transaction():
+        file_id = db.insert_file(repo_id, "orders.sql", "sql", "abc")
+        orders_table = db.insert_node(file_id, "table", "orders", "sql")
+        orders_query = db.insert_node(file_id, "query", "orders", "sql")
+        consumer_id = db.insert_node(file_id, "query", "marts.revenue", "sql")
+
+        db.insert_edge(orders_query, orders_table, "inserts_into")   # self-loop
+        db.insert_edge(consumer_id, orders_table, "references")      # real consumer
+        db.insert_column_usage(consumer_id, "orders", "amount", "select", file_id)
+
+    try:
+        result = db.query_check_impact(
+            "orders",
+            [{"action": "add_column", "column": "new_field"}],
+        )
+        safe_models = {s["model"] for s in result["impacts"][0]["safe"]}
+        # The file-stem query's inserts_into self-loop must not surface as a
+        # downstream consumer — only the real references-based consumer does.
+        assert "orders" not in safe_models, (
+            f"inserts_into self-loop leaked into downstream consumers: {safe_models}"
+        )
+        assert "marts.revenue" in safe_models
     finally:
         db.close()

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1774,6 +1774,47 @@ def test_check_impact_nonexistent_model():
     db.close()
 
 
+def test_check_impact_ignores_defines_edge_when_kind_filter():
+    """#127: downstream discovery must exclude the file-stem `query` node
+    that defines the target table, regardless of whether node_rows happens
+    to include that query.
+
+    Today node_rows includes every node sharing the model name, so the
+    defining query node is hidden by the NOT IN clause. When the file stem
+    and the target table don't share a name (e.g. a ``build_orders.sql``
+    whose CREATE target is ``staging.orders``), node_rows only contains
+    the table — and without the explicit defines filter the defining
+    query node surfaces as a phantom downstream consumer.
+    """
+    from sqlprism.core.graph import GraphDB
+
+    db = GraphDB()
+    repo_id = db.upsert_repo("test", "/tmp/test", repo_type="sql")
+    with db.write_transaction():
+        file_id = db.insert_file(repo_id, "build_orders.sql", "sql", "abc")
+        target_id = db.insert_node(file_id, "table", "staging.orders", "sql")
+        definer_id = db.insert_node(file_id, "query", "build_orders", "sql")
+        real_consumer_id = db.insert_node(file_id, "query", "marts.revenue", "sql")
+        db.insert_edge(definer_id, target_id, "defines", "CREATE statement")
+        db.insert_edge(real_consumer_id, target_id, "references")
+        db.insert_column_usage(real_consumer_id, "staging.orders", "amount", "select", file_id)
+
+    result = db.query_check_impact(
+        "staging.orders",
+        [{"action": "add_column", "column": "new_field"}],
+    )
+
+    # add_column classifies every downstream as safe — so the full list of
+    # downstream consumers surfaces there. The defining query must not appear.
+    safe_models = {s["model"] for s in result["impacts"][0]["safe"]}
+    assert "build_orders" not in safe_models, (
+        f"defining query node leaked into downstream consumers: {safe_models}"
+    )
+    assert "marts.revenue" in safe_models
+
+    db.close()
+
+
 def test_check_impact_column_change_validation():
     """ColumnChange validator rejects missing required fields."""
     import pytest

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1774,17 +1774,18 @@ def test_check_impact_nonexistent_model():
     db.close()
 
 
-def test_check_impact_ignores_defines_edge_when_kind_filter():
+def test_check_impact_excludes_defining_query_when_file_stem_differs():
     """#127: downstream discovery must exclude the file-stem `query` node
-    that defines the target table, regardless of whether node_rows happens
-    to include that query.
+    that defines the target table even when it has a different name.
 
-    Today node_rows includes every node sharing the model name, so the
-    defining query node is hidden by the NOT IN clause. When the file stem
-    and the target table don't share a name (e.g. a ``build_orders.sql``
-    whose CREATE target is ``staging.orders``), node_rows only contains
-    the table — and without the explicit defines filter the defining
-    query node surfaces as a phantom downstream consumer.
+    Today ``query_check_impact`` resolves ``node_rows`` by name only, so a
+    colliding file stem hides the ``defines`` edge via the NOT IN clause
+    by accident. When the file stem and the target table differ (e.g. a
+    ``build_orders.sql`` whose CREATE target is ``staging.orders``),
+    ``node_rows`` only contains the table — and without the explicit
+    defines filter the defining query surfaces as a phantom consumer. The
+    filter also covers every ``remove_column`` / ``rename_column`` change
+    bucket, not just ``add_column``.
     """
     from sqlprism.core.graph import GraphDB
 
@@ -1799,20 +1800,33 @@ def test_check_impact_ignores_defines_edge_when_kind_filter():
         db.insert_edge(real_consumer_id, target_id, "references")
         db.insert_column_usage(real_consumer_id, "staging.orders", "amount", "select", file_id)
 
-    result = db.query_check_impact(
-        "staging.orders",
-        [{"action": "add_column", "column": "new_field"}],
-    )
+    try:
+        # add_column: every downstream surfaces in safe — definer must not
+        add_result = db.query_check_impact(
+            "staging.orders",
+            [{"action": "add_column", "column": "new_field"}],
+        )
+        safe_models = {s["model"] for s in add_result["impacts"][0]["safe"]}
+        assert "build_orders" not in safe_models, (
+            f"defining query node leaked into safe consumers: {safe_models}"
+        )
+        assert "marts.revenue" in safe_models
 
-    # add_column classifies every downstream as safe — so the full list of
-    # downstream consumers surfaces there. The defining query must not appear.
-    safe_models = {s["model"] for s in result["impacts"][0]["safe"]}
-    assert "build_orders" not in safe_models, (
-        f"defining query node leaked into downstream consumers: {safe_models}"
-    )
-    assert "marts.revenue" in safe_models
-
-    db.close()
+        # remove_column: breaking classification must also exclude the definer
+        # (a regression where the filter only applied to the add_column branch
+        # would pass the assertion above but fail here).
+        rm_result = db.query_check_impact(
+            "staging.orders",
+            [{"action": "remove_column", "column": "amount"}],
+        )
+        impact = rm_result["impacts"][0]
+        surfaced = {x["model"] for x in impact["breaking"] + impact["warnings"] + impact["safe"]}
+        assert "build_orders" not in surfaced, (
+            f"defining query leaked into remove_column impact: {surfaced}"
+        )
+        assert "marts.revenue" in {b["model"] for b in impact["breaking"]}
+    finally:
+        db.close()
 
 
 def test_check_impact_column_change_validation():

--- a/tests/test_sql_parser.py
+++ b/tests/test_sql_parser.py
@@ -93,6 +93,30 @@ def test_multiple_statements():
     assert "users" in table_names
 
 
+def test_insert_into_file_stem_collision_emits_self_loop_edge():
+    """#127: when a file's stem collides with an INSERT target, the parser
+    emits ``file_stem (query) -[inserts_into]-> same-named table`` — the
+    exact self-loop shape the graph-level filter drops. Ensures that the
+    regression fixtures in test_graph.py / test_graph_tools.py mirror real
+    parser output: if sql.py:410 ever stops emitting this edge, the graph
+    tests could silently pass against stale assumptions.
+    """
+    sql = "INSERT INTO orders SELECT * FROM raw_orders;"
+    parser = SqlParser()
+    result = parser.parse("orders.sql", sql)
+
+    self_loop = [
+        e for e in result.edges
+        if e.source_name == "orders"
+        and e.target_name == "orders"
+        and e.relationship == "inserts_into"
+    ]
+    assert self_loop, (
+        "parser no longer emits the inserts_into self-loop; update the "
+        "graph-level regression fixtures accordingly"
+    )
+
+
 def test_invalid_sql_returns_empty():
     parser = SqlParser()
     result = parser.parse("bad.sql", "THIS IS NOT SQL AT ALL ???")


### PR DESCRIPTION
Closes #127

## Summary
- Extend the `defines`-edge exclusion added in PR #126 to every remaining graph query method that still followed CREATE-identity edges as if they were dataflow:
  - `query_find_path` — BFS recovery CTE drops `defines`; PGQ `MATCH` is unchanged because DuckPGQ's quantified edge binding does not accept a per-edge WHERE predicate, so the BFS acts as the post-filter.
  - `query_find_bottlenecks` — fan-in and upstream-count joins both drop `defines`.
  - `query_check_impact` — explicit `e.relationship <> 'defines'` (previously hid the bug only because `source_id NOT IN node_ids` happened to cover the file-stem query when name lookup returned both kinds).
- Narrow `inserts_into` filter: `_trace_cte` and `query_references` additionally drop `inserts_into` edges where `source.name = target.name`. This is the same self-loop shape as `defines` (the SQL parser emits `file_stem(query) -[inserts_into]-> target(table)` for INSERT statements, so a file stem colliding with the INSERT target resurrects the #122 bug). The narrow form preserves legitimate cross-table INSERT dataflow.

## Test Plan
| Scenario | Test | Status |
| --- | --- | --- |
| find_path('orders', 'orders') across a CTE-alias + defines fixture returns path_found false, not a length-1 self-path | tests/test_graph_tools.py::test_find_path_excludes_self_via_defines_edge | passing |
| find_bottlenecks downstream count for the declared table excludes the defines edge | tests/test_graph_tools.py::test_find_bottlenecks_ignores_defines_edge | passing |
| find_bottlenecks upstream count for the file-stem query excludes the defines edge | tests/test_graph_tools.py::test_find_bottlenecks_upstream_count_ignores_defines_edge | passing |
| check_impact excludes the file-stem query node even when node_rows contains only the table kind | tests/test_mcp_tools.py::test_check_impact_ignores_defines_edge_when_kind_filter | passing |
| INSERT INTO orders SELECT FROM raw_orders in orders.sql does not surface orders as its own upstream | tests/test_graph.py::test_inserts_into_file_stem_collision_no_self_loop | passing |
| Non-colliding cross-table INSERT still surfaces as a downstream reference | tests/test_graph.py::test_inserts_into_cross_table_dataflow_still_traced | passing |

Full test suite: 622 passing. `uv run ruff check .` and `uv run ty check` clean.

Note on `_NON_DATAFLOW_RELATIONSHIPS`: not extracted — `defines` is filtered universally, `inserts_into` only when source.name = target.name. A single constant would not capture both shapes.