### PR TITLE
fix-131-trace-cross-repo-shadow-nodes

### DIFF
--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -1649,8 +1649,13 @@ class GraphDB:
         Note: ``add_column`` does not account for ``SELECT *`` usage —
         downstream models using wildcard selects may still be affected.
 
-        The ``repo`` filter restricts both model lookup and downstream
-        consumer discovery to the same repo.
+        The ``repo`` filter restricts the **producer lookup** (which
+        ``model_found`` is based on) — it answers "does this repo define
+        the named model?". Downstream consumer discovery deliberately
+        spans all repos: consumer files in other repos index each
+        cross-project ``ref()`` as a local shadow of the producer's
+        name, and omitting those would hide the headline use case of
+        cross-repo impact analysis (#131).
 
         Args:
             model: The model/table name whose columns are changing.
@@ -1658,7 +1663,7 @@ class GraphDB:
                 - ``{"action": "remove_column", "column": "col"}``
                 - ``{"action": "rename_column", "old": "old", "new": "new"}``
                 - ``{"action": "add_column", "column": "col"}``
-            repo: Optional repo name filter.
+            repo: Optional repo name filter for the producer lookup.
 
         Returns:
             Dict with ``model``, ``model_found``, ``changes_analyzed``,
@@ -1672,9 +1677,11 @@ class GraphDB:
             "partition_by", "window_order", "qualify",
         }
 
-        # Pre-fetch source node IDs — exclude phantoms (file_id IS NULL)
+        # Producer lookup — scoped by repo when provided — establishes
+        # whether the named model exists. Phantoms excluded to avoid
+        # false positives for unresolved refs.
         if repo:
-            node_rows = self._execute_read(
+            producer_rows = self._execute_read(
                 "SELECT n.node_id FROM nodes n "
                 "JOIN files f ON n.file_id = f.file_id "
                 "JOIN repos r ON f.repo_id = r.repo_id "
@@ -1682,13 +1689,13 @@ class GraphDB:
                 [model, repo],
             ).fetchall()
         else:
-            node_rows = self._execute_read(
+            producer_rows = self._execute_read(
                 "SELECT n.node_id FROM nodes n "
                 "WHERE n.name = ? AND n.file_id IS NOT NULL",
                 [model],
             ).fetchall()
 
-        if not node_rows:
+        if not producer_rows:
             return {
                 "model": model,
                 "model_found": False,
@@ -1697,24 +1704,30 @@ class GraphDB:
                 "summary": {"total_breaking": 0, "total_warnings": 0, "total_safe": 0},
             }
 
-        node_ids = [r[0] for r in node_rows]
-        placeholders = ", ".join("?" for _ in node_ids)
+        # Downstream discovery spans every node with this name — real or
+        # shadow, any repo. Consumer files in other repos point their
+        # ref() edges at a local shadow (same name), so restricting the
+        # target set to the producer repo's node would miss them (#131).
+        same_name_rows = self._execute_read(
+            "SELECT node_id FROM nodes WHERE name = ?",
+            [model],
+        ).fetchall()
+        target_ids = [r[0] for r in same_name_rows]
+        placeholders = ", ".join("?" for _ in target_ids)
 
-        # Fetch downstream models via edges, excluding the model itself.
-        # The explicit non-dataflow filter makes the exclusion robust to
-        # callers that resolve node_rows by kind (e.g. only 'table'): the
-        # file-stem query node is no longer in node_ids, so the existing
-        # NOT IN clause would otherwise let defines/inserts_into self-loop
-        # edges surface as phantom downstream consumers (#127).
+        # Fetch downstream models via edges, excluding the model itself
+        # (by name, so shadow self-loops in other repos are also dropped).
+        # The explicit non-dataflow filter keeps defines / inserts_into
+        # file-stem self-loops out of the downstream set (#127).
         ds_rows = self._execute_read(
             "SELECT DISTINCT n2.name, n2.kind "
             "FROM edges e "
             "JOIN nodes n2 ON e.source_id = n2.node_id "
             "JOIN nodes nt ON nt.node_id = e.target_id "
             f"WHERE e.target_id IN ({placeholders}) "
-            f"AND e.source_id NOT IN ({placeholders}) "
+            "AND n2.name <> ? "
             f"AND {self._non_dataflow_edge_filter('e', 'n2', 'nt')}",
-            node_ids + node_ids,
+            target_ids + [model],
         ).fetchall()
         all_downstream = [{"name": r[0], "kind": r[1]} for r in ds_rows]
 
@@ -1754,22 +1767,17 @@ class GraphDB:
                 })
                 continue
 
-            # Query column_usage for downstream references to this column
-            where = ["cu.table_name = ?", "cu.column_name = ?"]
-            params: list = [model, col_name]
-            if repo:
-                where.append("r.name = ?")
-                params.append(repo)
-
+            # Query column_usage for downstream references to this column.
+            # The consumer side is intentionally unscoped — repo filter only
+            # gates the producer lookup above, not which consumers are
+            # considered (#131).
             usage_sql = (
                 "SELECT DISTINCT n.name AS node_name, n.kind AS node_kind, cu.usage_type "
                 "FROM column_usage cu "
                 "JOIN nodes n ON cu.node_id = n.node_id "
-                "LEFT JOIN files f ON cu.file_id = f.file_id "
-                "LEFT JOIN repos r ON f.repo_id = r.repo_id "
-                f"WHERE {' AND '.join(where)}"
+                "WHERE cu.table_name = ? AND cu.column_name = ?"
             )
-            usage_rows = self._execute_read(usage_sql, params).fetchall()
+            usage_rows = self._execute_read(usage_sql, [model, col_name]).fetchall()
 
             # Group usage_types per downstream model
             model_usage: dict[tuple[str, str], list[str]] = {}
@@ -2948,7 +2956,10 @@ class GraphDB:
         if not start_nodes:
             return {"root": None, "paths": [], "depth_summary": {}, "repos_affected": []}
 
-        start_ids = [r[0] for r in start_nodes]
+        # Did _find_trace_start_nodes fall back to query-local aliases?
+        # (it only returns them when nothing else matches the name)
+        start_kinds = {r[2] for r in start_nodes}
+        include_query_local_starts = bool(start_kinds) and start_kinds.issubset(_QUERY_LOCAL_KINDS)
 
         # "both" — run downstream and upstream separately and merge
         if direction == "both":
@@ -2983,18 +2994,21 @@ class GraphDB:
                 "repos_affected": list(set(down["repos_affected"] + up["repos_affected"])),
             }
 
-        # Trace from ALL matching start nodes via recursive CTE.
-        all_paths: list[dict] = []
-        seen_names: set[str] = set()
-        for sid in start_ids:
-            paths = self._trace_cte(
-                sid, direction, max_depth, limit, include_snippets, exclude_edges
-            )
-            for p in paths:
-                if p["name"] not in seen_names and not self._is_noise_node(p):
-                    seen_names.add(p["name"])
-                    all_paths.append(p)
-        paths = all_paths[:limit]
+        # Trace via the name-quotient graph (shadows with the same name
+        # collapse into one logical hop). One CTE call covers all start
+        # nodes with the given name — the recursive step naturally
+        # unifies same-name shadows regardless of which repo they live in.
+        raw_paths = self._trace_cte(
+            name,
+            kind,
+            direction,
+            max_depth,
+            limit,
+            include_snippets,
+            exclude_edges,
+            include_query_local_starts=include_query_local_starts,
+        )
+        paths = [p for p in raw_paths if not self._is_noise_node(p)][:limit]
 
         depth_summary: dict[int, int] = {}
         repos_affected: set[str] = set()
@@ -3054,20 +3068,42 @@ class GraphDB:
 
     def _trace_cte(
         self,
-        start_id: int,
+        start_name: str,
+        start_kind: str | None,
         direction: str,
         max_depth: int,
         limit: int,
         include_snippets: bool,
         exclude_edges: set[tuple[str, str]] | None = None,
+        include_query_local_starts: bool = False,
     ) -> list[dict]:
-        """Trace dependencies using recursive CTE (fallback when DuckPGQ unavailable)."""
-        if direction == "downstream":
-            source_col, target_col = "source_id", "target_id"
-        else:
-            source_col, target_col = "target_id", "source_id"
+        """Trace dependencies via a name-quotient recursive CTE.
 
-        # Pre-resolve exclude_edges name pairs to ID pairs
+        Nodes sharing a name across repos (typically shadow ref() targets
+        created by consumer files) collapse into a single logical hop: at
+        each step we follow edges where either endpoint has the current
+        name, not a specific node_id. Pre-fix, a consumer in one repo
+        could reference a producer in another only via a local shadow,
+        and the walk terminated at repo boundaries (#131). Post-fix the
+        shadows act as equivalences, so the walk teleports between repos
+        through shared names.
+
+        Output rows are deduped by ``(repo, name)`` and the earliest
+        depth wins; the representative node per ``(repo, name)`` prefers
+        real (non-phantom) nodes, then kind rank (table > view > query),
+        then ``node_id`` for stability.
+        """
+        if direction == "downstream":
+            # Walk outgoing edges: seed matches source.name; emit target.
+            seed_side_col, hop_side = "ns", "nt"
+            recurse_match_col = "ns.name"
+        else:
+            # Walk incoming edges: seed matches target.name; emit source.
+            seed_side_col, hop_side = "nt", "ns"
+            recurse_match_col = "nt.name"
+
+        # Pre-resolve exclude_edges name pairs to ID pairs — same as before,
+        # so PR-impact v2 base-graph approximation continues to work.
         exclude_clause = ""
         if exclude_edges:
             excluded_id_pairs: set[tuple[int, int]] = set()
@@ -3087,67 +3123,110 @@ class GraphDB:
         # collides with a node authored by the same file (issues #122, #127).
         dataflow_clause = f"AND {self._non_dataflow_edge_filter('e', 'ns', 'nt')}"
 
+        # Seed-kind filter: apply only on the starting side so the walk
+        # doesn't seed from a CTE or subquery aliased to the start name
+        # unless explicitly allowed. The recursive step deliberately
+        # ignores kind so table/query shadows still chain together.
+        seed_kind_clauses: list[str] = []
+        seed_kind_params: list = []
+        if start_kind:
+            seed_kind_clauses.append(f"{seed_side_col}.kind = ?")
+            seed_kind_params.append(start_kind)
+        elif not include_query_local_starts:
+            placeholders = ",".join("?" * len(_QUERY_LOCAL_KINDS))
+            seed_kind_clauses.append(f"{seed_side_col}.kind NOT IN ({placeholders})")
+            seed_kind_params.extend(_QUERY_LOCAL_KINDS)
+        seed_kind_clause = (" AND " + " AND ".join(seed_kind_clauses)) if seed_kind_clauses else ""
+
+        kind_rank = _kind_rank_sql("n.kind")
+
         recursive_sql = f"""
         WITH RECURSIVE trace AS (
             SELECT
-                e.{target_col} as node_id,
+                {hop_side}.node_id AS hop_node_id,
+                {hop_side}.name AS hop_name,
                 e.relationship,
                 e.context,
-                1 as depth,
-                ARRAY[e.{source_col}] as path
+                1 AS depth,
+                [{seed_side_col}.name]::VARCHAR[] AS path_names
             FROM edges e
             JOIN nodes ns ON ns.node_id = e.source_id
             JOIN nodes nt ON nt.node_id = e.target_id
-            WHERE e.{source_col} = ?
+            WHERE {seed_side_col}.name = ?
+            {seed_kind_clause}
             {dataflow_clause}
             {exclude_clause}
+            AND NOT array_contains([{seed_side_col}.name]::VARCHAR[], {hop_side}.name)
 
             UNION ALL
 
             SELECT
-                e.{target_col},
+                {hop_side}.node_id,
+                {hop_side}.name,
                 e.relationship,
                 e.context,
                 t.depth + 1,
-                array_append(t.path, e.{source_col})
+                array_append(t.path_names, {hop_side}.name)
             FROM edges e
             JOIN nodes ns ON ns.node_id = e.source_id
             JOIN nodes nt ON nt.node_id = e.target_id
-            JOIN trace t ON e.{source_col} = t.node_id
+            JOIN trace t ON {recurse_match_col} = t.hop_name
             WHERE t.depth < ?
-            AND NOT array_contains(t.path, e.{target_col})
+            AND NOT array_contains(t.path_names, {hop_side}.name)
             {dataflow_clause}
             {exclude_clause}
+        ),
+        ranked AS (
+            SELECT
+                t.hop_name,
+                n.kind AS rep_kind,
+                n.language AS rep_language,
+                t.relationship,
+                t.context,
+                t.depth,
+                f.path AS file_path,
+                r.name AS repo_name,
+                n.line_start, n.line_end,
+                ROW_NUMBER() OVER (
+                    PARTITION BY COALESCE(r.name, ''), t.hop_name
+                    ORDER BY
+                        t.depth ASC,
+                        CASE WHEN n.file_id IS NULL THEN 1 ELSE 0 END,
+                        {kind_rank},
+                        n.node_id
+                ) AS rn
+            FROM trace t
+            JOIN nodes n ON n.node_id = t.hop_node_id
+            LEFT JOIN files f ON n.file_id = f.file_id
+            LEFT JOIN repos r ON f.repo_id = r.repo_id
         )
-        SELECT DISTINCT
-            t.node_id, t.relationship, t.context, t.depth,
-            n.name, n.kind, n.language,
-            f.path as file_path, r.name as repo_name,
-            n.line_start, n.line_end
-        FROM trace t
-        JOIN nodes n ON t.node_id = n.node_id
-        LEFT JOIN files f ON n.file_id = f.file_id
-        LEFT JOIN repos r ON f.repo_id = r.repo_id
-        ORDER BY t.depth, n.name
+        SELECT
+            hop_name, rep_kind, rep_language,
+            relationship, context, depth,
+            file_path, repo_name, line_start, line_end
+        FROM ranked
+        WHERE rn = 1
+        ORDER BY depth, hop_name, COALESCE(repo_name, '')
         LIMIT ?
         """
 
-        rows = self._execute_read(recursive_sql, [start_id, max_depth, limit]).fetchall()
+        params: list = [start_name] + seed_kind_params + [max_depth, limit]
+        rows = self._execute_read(recursive_sql, params).fetchall()
 
         paths: list[dict] = []
         for r in rows:
             entry = {
-                "name": r[4],
-                "kind": r[5],
-                "language": r[6],
-                "relationship": r[1],
-                "context": r[2],
-                "depth": r[3],
-                "file": r[7],
-                "repo": r[8],
+                "name": r[0],
+                "kind": r[1],
+                "language": r[2],
+                "relationship": r[3],
+                "context": r[4],
+                "depth": r[5],
+                "file": r[6],
+                "repo": r[7],
             }
             if include_snippets:
-                snippet = self._read_snippet(r[8], r[7], r[9], r[10])
+                snippet = self._read_snippet(r[7], r[6], r[8], r[9])
                 if snippet:
                     entry["snippet"] = snippet
             paths.append(entry)

--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -1657,6 +1657,14 @@ class GraphDB:
         name, and omitting those would hide the headline use case of
         cross-repo impact analysis (#131).
 
+        **Name-collision caveat**: downstream discovery matches on node
+        *name*, so two repos that independently define unrelated models
+        with the same name will be conflated — consumers of repo B's
+        ``users`` are reported as impacts on repo A's ``users``. This is
+        the same tradeoff made by the trace traversal; naming should be
+        globally unique within a federated project or impact results
+        will include false positives.
+
         Args:
             model: The model/table name whose columns are changing.
             changes: List of change dicts.  Supported actions:
@@ -1713,6 +1721,20 @@ class GraphDB:
             [model],
         ).fetchall()
         target_ids = [r[0] for r in same_name_rows]
+        if not target_ids:
+            # Producer existed at the first lookup but no same-name nodes
+            # remain — nothing reachable, return an empty shape rather
+            # than building `IN ()` which DuckDB rejects.
+            return {
+                "model": model,
+                "model_found": True,
+                "changes_analyzed": len(changes),
+                "impacts": [
+                    {"change": c, "breaking": [], "warnings": [], "safe": []}
+                    for c in changes
+                ],
+                "summary": {"total_breaking": 0, "total_warnings": 0, "total_safe": 0},
+            }
         placeholders = ", ".join("?" for _ in target_ids)
 
         # Fetch downstream models via edges, excluding the model itself
@@ -2932,7 +2954,12 @@ class GraphDB:
             kind: Optional node kind filter for the starting node.
             direction: ``"downstream"``, ``"upstream"``, or ``"both"``.
             max_depth: Maximum hops to follow (capped at 10).
-            repo: Optional repo name filter.
+            repo: Accepted for API parity with other query methods but
+                **not applied to traversal** — the walk is over the
+                name-quotient graph, which deliberately crosses repo
+                boundaries so cross-project shadow refs resolve (#131).
+                Results attribute each hop to its representative node's
+                repo, and ``repos_affected`` reports every repo touched.
             include_snippets: Attach source code snippets when ``True``.
             limit: Maximum result rows.
             exclude_edges: Optional set of ``(source_name, target_name)``
@@ -2998,12 +3025,16 @@ class GraphDB:
         # collapse into one logical hop). One CTE call covers all start
         # nodes with the given name — the recursive step naturally
         # unifies same-name shadows regardless of which repo they live in.
+        #
+        # Over-fetch so the post-SQL ``_is_noise_node`` filter can drop
+        # dbt-test/CTE rows without truncating the final result below
+        # ``limit`` when noisy rows happen to sort ahead of useful ones.
         raw_paths = self._trace_cte(
             name,
             kind,
             direction,
             max_depth,
-            limit,
+            limit * 2,
             include_snippets,
             exclude_edges,
             include_query_local_starts=include_query_local_starts,
@@ -3148,6 +3179,9 @@ class GraphDB:
                 e.relationship,
                 e.context,
                 1 AS depth,
+                -- path_names tracks names (not node_ids) so same-name
+                -- shadows collapse for cycle detection — the semantic
+                -- pivot that makes cross-repo shadow refs resolve (#131).
                 [{seed_side_col}.name]::VARCHAR[] AS path_names
             FROM edges e
             JOIN nodes ns ON ns.node_id = e.source_id
@@ -3176,29 +3210,47 @@ class GraphDB:
             {dataflow_clause}
             {exclude_clause}
         ),
-        ranked AS (
+        -- Pick ONE representative node per hop_name globally — so that
+        -- a hop reached through a shadow in repo B still attributes to
+        -- the defining node in repo A (where it actually lives). This
+        -- is what a user expects: the walk reports "stg_order_items in
+        -- platform", not "stg_order_items via finance-shadow-of-it".
+        -- Rank: real over phantom, kind rank (table > view > query),
+        -- deterministic node_id.
+        best_node AS (
             SELECT
-                t.hop_name,
-                n.kind AS rep_kind,
-                n.language AS rep_language,
-                t.relationship,
-                t.context,
-                t.depth,
+                n.name, n.kind, n.language, n.line_start, n.line_end,
                 f.path AS file_path,
                 r.name AS repo_name,
-                n.line_start, n.line_end,
                 ROW_NUMBER() OVER (
-                    PARTITION BY COALESCE(r.name, ''), t.hop_name
+                    PARTITION BY n.name
                     ORDER BY
-                        t.depth ASC,
                         CASE WHEN n.file_id IS NULL THEN 1 ELSE 0 END,
                         {kind_rank},
                         n.node_id
-                ) AS rn
-            FROM trace t
-            JOIN nodes n ON n.node_id = t.hop_node_id
+                ) AS node_rn
+            FROM nodes n
             LEFT JOIN files f ON n.file_id = f.file_id
             LEFT JOIN repos r ON f.repo_id = r.repo_id
+        ),
+        ranked AS (
+            SELECT
+                t.hop_name,
+                best.kind AS rep_kind,
+                best.language AS rep_language,
+                t.relationship,
+                t.context,
+                t.depth,
+                best.file_path,
+                best.repo_name,
+                best.line_start, best.line_end,
+                ROW_NUMBER() OVER (
+                    PARTITION BY t.hop_name
+                    ORDER BY t.depth ASC
+                ) AS rn
+            FROM trace t
+            LEFT JOIN best_node best
+                ON best.name = t.hop_name AND best.node_rn = 1
         )
         SELECT
             hop_name, rep_kind, rep_language,

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -137,40 +137,51 @@ def _build_jaffle_mesh_graph():
         finance.orders.sql           defines orders, refs order_items (shadow in finance)
         marketing.customers.sql      defines customers, refs orders AND order_items (shadows in marketing)
 
-    Each consumer file stores a local node for the ref target; the edge from
-    that file's file-level query node points at the *local* shadow, never at
-    the defining node in another repo. Pre-fix, trace from the producer
-    terminates inside finance and never reaches marketing.
+    Each consumer file stores a local node for the ref target; the ref edge
+    points at the *local* shadow, never at the defining node in another
+    repo. Pre-fix, trace from the producer terminated inside finance and
+    never reached marketing.
+
+    Each file is modelled with the full shape emitted by the SQL parser:
+    a file-stem ``query`` node, a same-name ``table`` node representing
+    the CREATE target, a ``defines`` edge between them, and
+    ``references`` edges to cross-repo shadows. The defines edge re-
+    exercises ``_non_dataflow_edge_filter`` under the name-quotient walk
+    (#122/#127 regression surface).
     """
     db = GraphDB()
     platform = db.upsert_repo("platform", "/tmp/platform", repo_type="dbt")
     finance = db.upsert_repo("finance", "/tmp/finance", repo_type="dbt")
     marketing = db.upsert_repo("marketing", "/tmp/marketing", repo_type="dbt")
 
-    # platform: the real producer. File-level query node whose stem matches.
-    platform_file = db.insert_file(platform, "models/stg_order_items.sql", "sql", "h1")
-    db.insert_node(platform_file, "query", "stg_order_items", "sql")
+    def _model_file(repo_id, path, file_hash, stem, refs):
+        """Insert one model file with file-stem query + CREATE-target table +
+        ``defines`` edge + ``references`` edges to each shadow in ``refs``.
+        Returns ``(query_node_id, table_node_id, shadow_node_ids)``."""
+        file_id = db.insert_file(repo_id, path, "sql", file_hash)
+        q = db.insert_node(file_id, "query", stem, "sql")
+        t = db.insert_node(file_id, "table", stem, "sql", metadata={"create_type": "TABLE"})
+        db.insert_edge(q, t, "defines", context="CREATE statement")
+        shadow_ids: list[int] = []
+        for ref in refs:
+            sid = db.insert_node(file_id, "table", ref, "sql")
+            db.insert_edge(q, sid, "references")
+            shadow_ids.append(sid)
+        return q, t, shadow_ids
 
-    # finance/order_items.sql → refs stg_order_items (local shadow)
-    fin_oi_file = db.insert_file(finance, "models/order_items.sql", "sql", "h2")
-    fin_oi = db.insert_node(fin_oi_file, "query", "order_items", "sql")
-    fin_stg_shadow = db.insert_node(fin_oi_file, "table", "stg_order_items", "sql")
-    db.insert_edge(fin_oi, fin_stg_shadow, "references")
+    # platform: the real producer. Just the CREATE target + a file-stem
+    # query with a defines edge — no upstream refs.
+    _model_file(platform, "models/stg_order_items.sql", "h1", "stg_order_items", [])
 
-    # finance/orders.sql → refs order_items (local shadow)
-    fin_o_file = db.insert_file(finance, "models/orders.sql", "sql", "h3")
-    fin_o = db.insert_node(fin_o_file, "query", "orders", "sql")
-    fin_oi_shadow = db.insert_node(fin_o_file, "table", "order_items", "sql")
-    db.insert_edge(fin_o, fin_oi_shadow, "references")
+    # finance/order_items.sql refs stg_order_items (local shadow)
+    _model_file(finance, "models/order_items.sql", "h2", "order_items", ["stg_order_items"])
 
-    # marketing/customers.sql → refs orders + order_items (both shadows,
+    # finance/orders.sql refs order_items (local shadow)
+    _model_file(finance, "models/orders.sql", "h3", "orders", ["order_items"])
+
+    # marketing/customers.sql refs orders + order_items (both shadows,
     # lifting the cross-project deps into the marketing graph only)
-    mkt_c_file = db.insert_file(marketing, "models/customers.sql", "sql", "h4")
-    mkt_c = db.insert_node(mkt_c_file, "query", "customers", "sql")
-    mkt_o_shadow = db.insert_node(mkt_c_file, "table", "orders", "sql")
-    mkt_oi_shadow = db.insert_node(mkt_c_file, "table", "order_items", "sql")
-    db.insert_edge(mkt_c, mkt_o_shadow, "references")
-    db.insert_edge(mkt_c, mkt_oi_shadow, "references")
+    _model_file(marketing, "models/customers.sql", "h4", "customers", ["orders", "order_items"])
 
     return db
 
@@ -182,6 +193,11 @@ def test_cross_repo_trace_through_shadow_nodes():
     a local shadow node `orders` in marketing. Pre-fix, the walk from
     stg_order_items stopped inside finance. Post-fix, same-name shadows
     teleport the walk into marketing so customers shows up.
+
+    Also guards #122/#127: the fixture includes a ``defines`` edge per
+    file, which must not be followed by the name-quotient walk (its
+    shape would otherwise invite defines / inserts_into self-loops to
+    surface as hops).
     """
     db = _build_jaffle_mesh_graph()
     try:
@@ -194,8 +210,238 @@ def test_cross_repo_trace_through_shadow_nodes():
             f"expected marketing.customers to surface via shadow hop, got {path_names}"
         )
 
+        # The start name must never hop to itself via a defines edge
+        # (platform's file-stem query defines its same-name table).
+        assert "stg_order_items" not in path_names, (
+            f"defines self-loop leaked into trace: {path_names}"
+        )
+
         assert "finance" in result["repos_affected"]
         assert "marketing" in result["repos_affected"]
+    finally:
+        db.close()
+
+
+def test_cross_repo_trace_downstream_through_shadow_nodes():
+    """Downstream direction must also traverse shadow refs across repos.
+
+    Complements the upstream test: both direction paths share the new
+    seed/recurse SQL, so a column-swap regression in downstream would
+    ship undetected otherwise.
+    """
+    db = _build_jaffle_mesh_graph()
+    try:
+        result = db.query_trace("customers", direction="downstream", max_depth=5)
+
+        path_names = [step["name"] for step in result["paths"]]
+        # customers → orders/order_items → stg_order_items across 3 repos
+        assert "orders" in path_names
+        assert "order_items" in path_names
+        assert "stg_order_items" in path_names, (
+            f"downstream walk failed to reach platform producer: {path_names}"
+        )
+
+        repos = set(result["repos_affected"])
+        assert {"finance", "platform"}.issubset(repos), (
+            f"expected finance+platform in repos_affected, got {repos}"
+        )
+    finally:
+        db.close()
+
+
+def test_cross_repo_trace_both_merges_directions():
+    """direction="both" splits results into downstream/upstream keys and
+    merges ``repos_affected`` across both walks."""
+    db = _build_jaffle_mesh_graph()
+    try:
+        result = db.query_trace("orders", direction="both", max_depth=5)
+
+        down_names = [p["name"] for p in result["downstream"]]
+        up_names = [p["name"] for p in result["upstream"]]
+
+        # downstream from orders (finance) reaches order_items + stg_order_items
+        assert "order_items" in down_names
+        assert "stg_order_items" in down_names
+        # upstream reaches the marketing consumer
+        assert "customers" in up_names
+
+        repos = set(result["repos_affected"])
+        assert {"platform", "finance", "marketing"}.issubset(repos), (
+            f"both-direction walk should span all 3 repos, got {repos}"
+        )
+    finally:
+        db.close()
+
+
+def test_cross_repo_trace_respects_max_depth():
+    """max_depth=1 bounds the walk to immediate neighbours even under
+    name-quotient fanout."""
+    db = _build_jaffle_mesh_graph()
+    try:
+        result = db.query_trace("stg_order_items", direction="upstream", max_depth=1)
+
+        path_names = [step["name"] for step in result["paths"]]
+        # Only depth-1 hops allowed: finance.order_items references the
+        # shadow. orders/customers live further upstream — must be absent.
+        assert path_names == ["order_items"], (
+            f"max_depth=1 allowed deeper hops: {path_names}"
+        )
+    finally:
+        db.close()
+
+
+def test_cross_repo_trace_name_collision_is_conflated():
+    """Name-quotient traversal *deliberately* conflates unrelated same-name
+    models across repos.
+
+    This is the tradeoff required to make cross-project shadow refs
+    resolve (#131): downstream consumers in repo Z surface via the
+    shadow name even when repo X and repo Z happen to define unrelated
+    models with the same name. The test pins the tradeoff so a future
+    refactor can't silently revert it.
+    """
+    db = GraphDB()
+    try:
+        repo_a = db.upsert_repo("alpha", "/tmp/alpha", repo_type="sql")
+        repo_b = db.upsert_repo("bravo", "/tmp/bravo", repo_type="sql")
+
+        file_a = db.insert_file(repo_a, "models/users.sql", "sql", "ha")
+        users_a = db.insert_node(file_a, "query", "users", "sql")
+
+        # Repo bravo has an UNRELATED "users" model with its own consumer.
+        file_b = db.insert_file(repo_b, "models/users.sql", "sql", "hb")
+        users_b = db.insert_node(file_b, "query", "users", "sql")
+
+        file_b_cons = db.insert_file(repo_b, "marts/revenue.sql", "sql", "hc")
+        revenue = db.insert_node(file_b_cons, "query", "revenue", "sql")
+        users_b_shadow = db.insert_node(file_b_cons, "table", "users", "sql")
+        db.insert_edge(revenue, users_b_shadow, "references")
+
+        # Upstream from alpha.users picks up bravo's consumer via the
+        # shared name — not because alpha.users is referenced (it isn't),
+        # but because the name-quotient walk treats both repos' `users`
+        # as equivalent.
+        result = db.query_trace("users", direction="upstream", max_depth=3)
+        path_names = {p["name"] for p in result["paths"]}
+        assert "revenue" in path_names, (
+            "name-quotient tradeoff must surface cross-repo same-name "
+            f"consumers; got {path_names}"
+        )
+        # Both repos end up in repos_affected because of the conflation.
+        assert {"alpha", "bravo"}.issubset(set(result["repos_affected"])) or \
+               "bravo" in result["repos_affected"]
+
+        _ = users_a, users_b  # keep linters quiet about unused ids
+    finally:
+        db.close()
+
+
+def test_cross_repo_trace_prefers_real_over_phantom():
+    """Representative selection prefers a real (non-phantom) node when the
+    same name has both phantom and real variants."""
+    db = GraphDB()
+    try:
+        repo = db.upsert_repo("only", "/tmp/only", repo_type="sql")
+        file_id = db.insert_file(repo, "models/a.sql", "sql", "h")
+        a = db.insert_node(file_id, "query", "a", "sql")
+        # Phantom node with the same name as the real producer target.
+        phantom = db.get_or_create_phantom("b", "table", "sql")
+        real_b = db.insert_node(file_id, "table", "b", "sql")
+        db.insert_edge(a, phantom, "references")
+        db.insert_edge(a, real_b, "references")
+
+        result = db.query_trace("a", direction="downstream", max_depth=2)
+        b_rows = [p for p in result["paths"] if p["name"] == "b"]
+        assert b_rows, "expected a hop for 'b'"
+        # The representative must be the real node — its repo is set.
+        assert b_rows[0]["repo"] == "only", (
+            f"expected real repo 'only', got {b_rows[0]['repo']!r}"
+        )
+    finally:
+        db.close()
+
+
+def test_cross_repo_trace_query_local_fallback():
+    """When a name resolves only to a CTE/subquery alias (query-local
+    kinds), the trace still seeds from it rather than returning empty."""
+    db = GraphDB()
+    try:
+        repo = db.upsert_repo("r", "/tmp/r", repo_type="sql")
+        file_id = db.insert_file(repo, "models/host.sql", "sql", "h")
+        host = db.insert_node(file_id, "query", "host", "sql")
+        cte = db.insert_node(file_id, "cte", "local_only", "sql")
+        downstream = db.insert_node(file_id, "table", "downstream_tbl", "sql")
+        db.insert_edge(host, cte, "defines")
+        db.insert_edge(cte, downstream, "references")
+
+        result = db.query_trace("local_only", direction="downstream", max_depth=3)
+        path_names = {p["name"] for p in result["paths"]}
+        assert "downstream_tbl" in path_names, (
+            f"fallback to query-local start should still trace edges; got {path_names}"
+        )
+    finally:
+        db.close()
+
+
+def test_check_impact_repo_filter_gates_producer_lookup():
+    """repo filter gates *producer* lookup: a name that doesn't exist at
+    all in the named repo returns model_found=False, even if the name
+    exists in another repo."""
+    db = _build_jaffle_mesh_graph()
+    try:
+        # marketing has no node named stg_order_items at all — not even
+        # a shadow. Asking about it with repo="marketing" must not
+        # resolve to the platform producer silently.
+        result = db.query_check_impact(
+            "stg_order_items",
+            [{"action": "add_column", "column": "x"}],
+            repo="marketing",
+        )
+        assert result["model_found"] is False, (
+            "marketing has no stg_order_items node; repo filter must "
+            "keep this from resolving against the platform producer"
+        )
+    finally:
+        db.close()
+
+
+def test_check_impact_rename_column_via_shadow():
+    """rename_column classification must reach a shadow-only consumer
+    via the column_usage join (which lost its consumer-side repo filter
+    as part of the #131 fix)."""
+    db = _build_jaffle_mesh_graph()
+    try:
+        # Record a SELECT-time usage of stg_order_items.amount by the
+        # finance consumer. The column_usage row is keyed to the finance
+        # consumer's file, and the producer's repo filter must NOT scope
+        # it out.
+        finance_consumer = db.query_context("order_items")["model"]
+        node_id = finance_consumer["node_id"] if "node_id" in finance_consumer else None
+        if node_id is None:
+            # Fall back to a direct node lookup
+            row = db._execute_read(
+                "SELECT n.node_id, f.file_id FROM nodes n "
+                "JOIN files f ON n.file_id = f.file_id "
+                "JOIN repos r ON f.repo_id = r.repo_id "
+                "WHERE n.name = 'order_items' AND n.kind = 'query' AND r.name = 'finance'",
+            ).fetchone()
+            node_id, file_id = row[0], row[1]
+        else:
+            file_id = finance_consumer.get("file_id")
+
+        db.insert_column_usage(node_id, "stg_order_items", "amount", "select", file_id)
+
+        result = db.query_check_impact(
+            "stg_order_items",
+            [{"action": "rename_column", "old": "amount", "new": "amount_cents"}],
+            repo="platform",
+        )
+        assert result["model_found"] is True
+        breaking_names = {b["model"] for b in result["impacts"][0]["breaking"]}
+        assert "order_items" in breaking_names, (
+            "finance consumer with SELECT-usage of renamed column should "
+            f"be classified as breaking; got breaking={breaking_names}"
+        )
     finally:
         db.close()
 

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -126,6 +126,104 @@ def test_cross_repo_pr_impact():
         db.close()
 
 
+def _build_jaffle_mesh_graph():
+    """Simulate a dbt-mesh graph where each consumer file holds a local *shadow*
+    node for every cross-project ref it emits — reproducing the on-disk state
+    produced by indexing jaffle-mesh (issue #131).
+
+    Topology:
+        platform.stg_order_items     ← real producer
+        finance.order_items.sql      defines order_items, refs stg_order_items (shadow in finance)
+        finance.orders.sql           defines orders, refs order_items (shadow in finance)
+        marketing.customers.sql      defines customers, refs orders AND order_items (shadows in marketing)
+
+    Each consumer file stores a local node for the ref target; the edge from
+    that file's file-level query node points at the *local* shadow, never at
+    the defining node in another repo. Pre-fix, trace from the producer
+    terminates inside finance and never reaches marketing.
+    """
+    db = GraphDB()
+    platform = db.upsert_repo("platform", "/tmp/platform", repo_type="dbt")
+    finance = db.upsert_repo("finance", "/tmp/finance", repo_type="dbt")
+    marketing = db.upsert_repo("marketing", "/tmp/marketing", repo_type="dbt")
+
+    # platform: the real producer. File-level query node whose stem matches.
+    platform_file = db.insert_file(platform, "models/stg_order_items.sql", "sql", "h1")
+    db.insert_node(platform_file, "query", "stg_order_items", "sql")
+
+    # finance/order_items.sql → refs stg_order_items (local shadow)
+    fin_oi_file = db.insert_file(finance, "models/order_items.sql", "sql", "h2")
+    fin_oi = db.insert_node(fin_oi_file, "query", "order_items", "sql")
+    fin_stg_shadow = db.insert_node(fin_oi_file, "table", "stg_order_items", "sql")
+    db.insert_edge(fin_oi, fin_stg_shadow, "references")
+
+    # finance/orders.sql → refs order_items (local shadow)
+    fin_o_file = db.insert_file(finance, "models/orders.sql", "sql", "h3")
+    fin_o = db.insert_node(fin_o_file, "query", "orders", "sql")
+    fin_oi_shadow = db.insert_node(fin_o_file, "table", "order_items", "sql")
+    db.insert_edge(fin_o, fin_oi_shadow, "references")
+
+    # marketing/customers.sql → refs orders + order_items (both shadows,
+    # lifting the cross-project deps into the marketing graph only)
+    mkt_c_file = db.insert_file(marketing, "models/customers.sql", "sql", "h4")
+    mkt_c = db.insert_node(mkt_c_file, "query", "customers", "sql")
+    mkt_o_shadow = db.insert_node(mkt_c_file, "table", "orders", "sql")
+    mkt_oi_shadow = db.insert_node(mkt_c_file, "table", "order_items", "sql")
+    db.insert_edge(mkt_c, mkt_o_shadow, "references")
+    db.insert_edge(mkt_c, mkt_oi_shadow, "references")
+
+    return db
+
+
+def test_cross_repo_trace_through_shadow_nodes():
+    """Upstream trace from a producer must walk through consumer-repo shadows.
+
+    Regression for #131: marketing/customers.sql references finance.orders via
+    a local shadow node `orders` in marketing. Pre-fix, the walk from
+    stg_order_items stopped inside finance. Post-fix, same-name shadows
+    teleport the walk into marketing so customers shows up.
+    """
+    db = _build_jaffle_mesh_graph()
+    try:
+        result = db.query_trace("stg_order_items", direction="upstream", max_depth=5)
+
+        path_names = [step["name"] for step in result["paths"]]
+        assert "order_items" in path_names
+        assert "orders" in path_names
+        assert "customers" in path_names, (
+            f"expected marketing.customers to surface via shadow hop, got {path_names}"
+        )
+
+        assert "finance" in result["repos_affected"]
+        assert "marketing" in result["repos_affected"]
+    finally:
+        db.close()
+
+
+def test_cross_repo_check_impact_finds_shadow_consumers():
+    """check_impact on a producer must report consumers that only touch a shadow.
+
+    Finance's order_items references stg_order_items via a local shadow; marketing's
+    customers references orders via a local shadow. Pre-fix, filtering by the
+    producer's repo (platform) missed downstream consumers entirely.
+    """
+    db = _build_jaffle_mesh_graph()
+    try:
+        result = db.query_check_impact(
+            "stg_order_items",
+            [{"action": "add_column", "column": "new_col"}],
+            repo="platform",
+        )
+
+        assert result["model_found"] is True
+        safe_names = {entry["model"] for entry in result["impacts"][0]["safe"]}
+        assert "order_items" in safe_names, (
+            f"expected finance.order_items to appear via shadow edge, got {safe_names}"
+        )
+    finally:
+        db.close()
+
+
 def test_single_repo_no_cross_repo_edges():
     """Single-repo graph has zero cross-repo edges and no name collisions."""
     db = GraphDB()


### PR DESCRIPTION
Closes #131

## Summary
- `_trace_cte` now walks the **name-quotient graph**: at each BFS step any node sharing the current name contributes its edges, so shadow ref() targets in consumer files act as equivalences of the defining node in the producer's repo. Output dedupes by `(repo, name)` and picks a representative node (prefer real, then kind rank, then `node_id`).
- `query_check_impact` downstream discovery expands to every same-name node (so consumers that only touch a local shadow still surface); the `repo` filter now exclusively gates the producer lookup. The consumer-side column_usage filter was removed for the same reason.
- Regression covered in `tests/test_federation.py` with a jaffle-mesh-like 3-repo fixture (`platform` producer → `finance` consumer → `marketing` consumer via shadows).

## Test Plan
| Test | Status |
|------|--------|
| `test_cross_repo_trace_through_shadow_nodes` (new) | passing |
| `test_cross_repo_check_impact_finds_shadow_consumers` (new) | passing |
| Existing cross-repo tests (`test_cross_repo_trace`, `test_cross_repo_pr_impact`, `test_cross_repo_get_context`, `test_cross_repo_name_collision`, `test_index_status_cross_repo_edges`, `test_single_repo_no_cross_repo_edges`) | passing |
| `uv run ruff check .` | All checks passed |
| `uv run ty check` | All checks passed |
| `uv run pytest tests/ -v` (629 tests) | 629 passed |