### PR TITLE
chore: release v1.2.1 — dbt parsing & cross-repo stabilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ SQLPrism optionally integrates with [DuckPGQ](https://github.com/cwida/duckpgq) 
 
 ```bash
 uv sync
-uv run pytest                          # run tests (510+ tests)
+uv run pytest                          # run tests (630+ tests)
 uv run pytest --cov=sqlprism           # run with coverage report
 uv run pytest --cov=sqlprism --cov-report=html:coverage_html  # HTML report
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sqlprism"
-version = "1.2.0"
+version = "1.2.1"
 description = "SQL codebase indexer with column-level lineage, impact analysis, and MCP server support"
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -17,9 +17,9 @@ from sqlprism.types import (
 
 
 def test_version_string():
-    """Verify package version is 1.2.0."""
+    """Verify package version is 1.2.1."""
     version = importlib.metadata.version("sqlprism")
-    assert version == "1.2.0"
+    assert version == "1.2.1"
 
 
 def test_resolve_dialect_no_overrides():

--- a/uv.lock
+++ b/uv.lock
@@ -1436,7 +1436,7 @@ wheels = [
 
 [[package]]
 name = "sqlprism"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Patch release bumping to **v1.2.1**. Bug fixes only — no new MCP tools, CLI commands, or config.

Full release notes: see the drafted v1.2.1 release body (dbt parsing + cross-repo graph correctness stabilization).

## Changes

- `pyproject.toml` + `uv.lock`: `1.2.0` → `1.2.1`
- `README.md`: test count `510+` → `630+`

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run ty check` passes
- [x] 637 tests collected; existing CI will validate

## Release steps (after merge)

- [ ] Tag `v1.2.1` on the merge commit
- [ ] `gh release create v1.2.1` with drafted notes