### PR TITLE
chore(134): address critical review — docs, hygiene, silent failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 # Claude
 .claude/research/
 .claude/plans/
+.claude/specs/
 .claude/worktrees/
 .claude/settings.local.json
+.claude/*.lock
 .mcp.json
+
+# User config (personal paths)
+sqlprism.yml
 
 # Coverage
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.1] — 2026-04-21
+
+### Fixed
+- `find_path` / `find_bottlenecks` / `check_impact` no longer follow `defines`
+  (non-dataflow) edges or `inserts_into` self-loops when tracing dependencies
+  (#127).
+- Cross-repo trace now walks the name-quotient graph so dependency traversal
+  crosses shadow `ref()` nodes between federated repos (#131).
+- dbt `schema.yml` column definitions are persisted into the graph; column
+  inference from `CREATE TABLE AS SELECT` is also picked up (#125).
+- sqlmesh column-definition resolution aligned with the dbt path (#124).
+
+## [1.2.0] — 2026-03-26
+
+### Added
+- **Conventions engine**: layer detection, naming-pattern inference, reference
+  rules, common columns, and column-style inference. Exposed via
+  `get_conventions` MCP tool and the `sqlprism conventions --init/--refresh/--diff`
+  CLI. YAML overrides can be loaded and merged on top of inferred conventions.
+- **Semantic tags**: clustering and auto-labeling of models, with
+  `search_by_tag` and `list_tags` MCP tools.
+- **Similarity & placement**: `find_similar_models` and `suggest_placement`
+  MCP tools to support new-model authoring workflows.
+
+### Changed
+- Upgraded `sqlglot` to v30 with the `[c]` (native) extension for faster
+  parsing.
+
+## [1.1.0] — 2026-03-16
+
+### Added
+- **Cross-repo federation**: `cross_repo_edges` and `name_collisions` surfaced
+  via `get_index_status`; synthetic shadow nodes for referenced-but-unindexed
+  models.
+- **YAML config support** with discovery order; `sqlprism.yml` recognised
+  alongside legacy JSON.
+- **Graph-analytics tools**: `find_critical_models` (PageRank),
+  `detect_cycles`, `find_subgraphs` (weakly connected components), and
+  `find_bottlenecks` (fan-in/out analysis), backed by DuckPGQ.
+- **Column & context tools**: `get_schema`, `get_context`, `check_impact`,
+  `find_path`, and DuckPGQ-backed `trace_dependencies`.
+- `ty` type checker added to CI.
+
+## [1.0.1] — 2026-03-15
+
+### Fixed
+- Patch release following v1.0.0; see git history for details.
+
+## [1.0.0] — 2026-03-12
+
+### Added
+- Initial release: DuckDB-backed knowledge graph for SQL, dbt, and sqlmesh
+  repos. MCP server with parsing, indexing, lineage, impact analysis, and
+  column tracing.
+
+[Unreleased]: https://github.com/darkcofy/sqlprism/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/darkcofy/sqlprism/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/darkcofy/sqlprism/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/darkcofy/sqlprism/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/darkcofy/sqlprism/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/darkcofy/sqlprism/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ SQL knowledge graph MCP server — indexes SQL, dbt, and sqlmesh repos into a Du
 
 ## Quick Reference
 
-- **Language**: Python 3.12+
+- **Language**: Python 3.11+
 - **Package manager**: uv
 - **Lint**: `uv run ruff check .`
 - **Type check**: `uv run ty check`
@@ -18,7 +18,7 @@ src/sqlprism/
   core/
     graph.py       — DuckDB storage layer (MVCC, repo_type tracking)
     indexer.py      — Orchestrates parsing + indexing; file-level reindex with repo-type dispatch
-    mcp_tools.py   — MCP server tools (24 tools, non-blocking reindex, per-repo debounce)
+    mcp_tools.py   — MCP server tools (non-blocking reindex, per-repo debounce)
     conventions.py — Convention inference engine (layers, naming, references, tags, overrides)
   languages/
     sql.py         — sqlglot-based SQL parser

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to SQLPrism
+
+Thanks for your interest. This document covers the workflow, conventions, and
+checks that apply to all changes.
+
+## Development setup
+
+Requirements:
+
+- Python 3.11+
+- [uv](https://docs.astral.sh/uv/) package manager
+
+```bash
+git clone https://github.com/darkcofy/sqlprism.git
+cd sqlprism
+uv sync
+```
+
+This installs the package and dev dependencies (pytest, ruff, ty, mkdocs) into
+a local `.venv`.
+
+## Running checks locally
+
+Every PR must pass these before it is marked ready:
+
+```bash
+uv run ruff check .       # lint
+uv run ty check           # type check
+uv run pytest tests/ -v   # tests
+```
+
+To run a single test:
+
+```bash
+uv run pytest tests/test_indexer.py::test_name -v
+```
+
+Coverage is configured with a floor of 80% (`[tool.coverage.report] fail_under`).
+
+## Branch and PR conventions
+
+Branch names follow the pattern `<type>-<issue>-<short-description>`:
+
+- `feat-11-indexer-reindex-files`
+- `fix-131-trace-cross-repo-shadow-nodes`
+- `chore-134-critical-review-fixes`
+
+Valid types:
+
+- `feat` — new functionality or enhancement
+- `fix` — bug fix
+- `chore` — maintenance, refactors, docs, hygiene
+
+PR titles should mirror the branch name style. The PR body should link the
+issue with `Closes #<number>`. Open PRs as drafts first; mark them ready once
+`ruff`, `ty`, and `pytest` all pass locally.
+
+## Issue conventions
+
+Issues use a BDD format where applicable: `Given / When / Then` scenarios
+with concrete acceptance criteria. This makes it easier to decompose an issue
+into tasks and to know when it is done.
+
+## Documentation
+
+User-facing docs live under `docs/` and are published with MkDocs Material.
+Preview locally:
+
+```bash
+uv run mkdocs serve
+```
+
+Architectural or longer-form notes can also live under `docs/architecture/`.
+
+## Reporting security issues
+
+See [SECURITY.md](SECURITY.md). Please do not file public issues for
+suspected vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Full reference: [CLI guide](https://darkcofy.github.io/sqlprism/guide/cli/)
 
 Full reference: [MCP tools guide](https://darkcofy.github.io/sqlprism/guide/mcp-tools/)
 
-When running as an MCP server (`sqlprism serve`), 24 tools are exposed:
+When running as an MCP server (`sqlprism serve`), the following tools are exposed:
 
 | Tool | Description |
 |---|---|
@@ -256,7 +256,7 @@ src/sqlprism/
   core/
     graph.py            <- DuckDB storage layer (MVCC), queries, snippets, repo_type tracking
     indexer.py          <- Orchestrator: scan -> checksum -> parse -> store; file-level reindex with repo-type dispatch
-    mcp_tools.py        <- FastMCP tool definitions (24 tools, non-blocking reindex, per-repo debounce)
+    mcp_tools.py        <- FastMCP tool definitions (non-blocking reindex, per-repo debounce)
     conventions.py      <- Convention inference engine: layers, naming, references, tags, overrides
   cli.py                <- Click CLI: serve, reindex, reindex-file, reindex-sqlmesh, reindex-dbt, conventions, status, init
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security policy
+
+## Supported versions
+
+SQLPrism is pre-1.x in spirit (published as 1.x with a "Beta" development
+status). Only the latest minor release on the `main` branch receives security
+fixes.
+
+| Version | Supported |
+|---------|-----------|
+| 1.2.x   | Yes       |
+| < 1.2   | No        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for suspected vulnerabilities.
+
+Instead, email the maintainer at **alfjohnfred@gmail.com** with:
+
+- A description of the issue and its potential impact.
+- Steps to reproduce, or a minimal proof of concept.
+- Any relevant logs, stack traces, or affected commits.
+
+You can expect an acknowledgement within **72 hours**. If the report is
+confirmed, we will work on a fix and coordinate a release; you will be
+credited in the `CHANGELOG.md` entry unless you prefer to remain anonymous.
+
+## Scope
+
+In scope:
+
+- Arbitrary code execution, SQL injection, or path traversal in the parser,
+  indexer, CLI, or MCP server.
+- Secret leakage through logs, snippets, or the graph store.
+- Unsafe subprocess handling in the dbt / sqlmesh renderers.
+
+Out of scope:
+
+- Vulnerabilities in upstream dependencies (DuckDB, sqlglot, dbt, sqlmesh) —
+  please report those to the respective projects.
+- Findings that require the attacker to already control the machine running
+  `sqlprism serve`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,7 +8,7 @@
 ## Install from Source
 
 ```bash
-git clone <repo-url>
+git clone https://github.com/darkcofy/sqlprism.git
 cd sqlprism
 uv sync
 ```

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -34,7 +34,7 @@ sqlprism status [--config PATH] [--db PATH]
 
 ### `sqlprism serve`
 
-Starts the MCP server, exposing all 24 tools to any MCP client.
+Starts the MCP server, exposing all tools to any MCP client.
 
 ```bash
 sqlprism serve [--config PATH] [--db PATH] [--transport stdio|streamable-http] [--port 8000]

--- a/docs/guide/mcp-tools.md
+++ b/docs/guide/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools
 
-When running as an MCP server (`sqlprism serve`), 24 tools are exposed. Any MCP client (Claude Code, Claude Desktop, Cursor, Continue.dev) can call these.
+When running as an MCP server (`sqlprism serve`), the tools below are exposed. Any MCP client (Claude Code, Claude Desktop, Cursor, Continue.dev) can call these.
 
 ## Query Tools
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ On a 200-model SQLMesh project, a column impact query returns **75 structured re
 ## Quick Start
 
 ```bash
-git clone <repo-url> && cd sqlprism
+git clone https://github.com/darkcofy/sqlprism.git && cd sqlprism
 uv sync
 uv run sqlprism init       # creates sqlprism.yml
 # edit config to add your repos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ target-version = "py311"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP"]
+select = ["E", "F", "I", "N", "W", "UP", "B", "RUF"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/sqlprism/core/conventions.py
+++ b/src/sqlprism/core/conventions.py
@@ -717,7 +717,7 @@ class ConventionEngine:
         stripped = []
         matching_prefix = 0
         exceptions = []
-        for name, tokens in zip(model_names, tokenized):
+        for name, tokens in zip(model_names, tokenized, strict=False):
             if prefix_tokens and tokens[: len(prefix_tokens)] == prefix_tokens:
                 stripped.append(tokens[len(prefix_tokens) :])
                 matching_prefix += 1
@@ -758,7 +758,7 @@ class ConventionEngine:
             # Models not matching the dominant structure are exceptions
             exceptions = [
                 name
-                for name, tokens in zip(model_names, tokenized)
+                for name, tokens in zip(model_names, tokenized, strict=False)
                 if len(tokens) != most_common_len
             ]
 
@@ -1254,7 +1254,7 @@ class ConventionEngine:
 
         assignments: list[TagAssignment] = []
         for cluster in clusters:
-            tag_name, label_confidence = self._label_cluster(cluster)
+            tag_name, _label_confidence = self._label_cluster(cluster)
             if not tag_name:
                 continue
 

--- a/src/sqlprism/core/graph.py
+++ b/src/sqlprism/core/graph.py
@@ -34,7 +34,7 @@ import duckdb
 
 logger = logging.getLogger(__name__)
 
-_MAX_FILE_SIZE = 1 * 1024 * 1024  # 1 MB – skip snippets for oversized files
+_MAX_FILE_SIZE = 1 * 1024 * 1024  # 1 MB - skip snippets for oversized files
 _EXTEND_SUGGESTION_THRESHOLD = 0.8
 
 # Kinds that are query-local aliases — never a standalone entity a user would
@@ -71,7 +71,8 @@ def _read_file_lines(path: str) -> tuple[str, ...] | None:
         if p.stat().st_size > _MAX_FILE_SIZE:
             return None
         return tuple(p.read_text(errors="replace").splitlines())
-    except Exception:
+    except OSError as e:
+        logger.debug("Could not read %s for snippet extraction: %s", path, e)
         return None
 
 
@@ -873,7 +874,7 @@ class GraphDB:
                 "SELECT n.node_id FROM nodes n "
                 "JOIN files f ON n.file_id = f.file_id "
                 "WHERE n.name = ? AND n.kind = ? AND f.repo_id = ?" + schema_clause + " LIMIT 1",
-                [name, kind, repo_id] + schema_params,
+                [name, kind, repo_id, *schema_params],
             ).fetchone()
             if row:
                 return row[0]
@@ -882,7 +883,7 @@ class GraphDB:
             # 2. Exact kind match cross-repo
             row = self._execute_read(
                 "SELECT n.node_id FROM nodes n WHERE n.name = ? AND n.kind = ?" + schema_clause + " LIMIT 1",
-                [name, kind] + schema_params,
+                [name, kind, *schema_params],
             ).fetchone()
             if row:
                 return row[0]
@@ -899,7 +900,7 @@ class GraphDB:
                 "JOIN files f ON n.file_id = f.file_id "
                 "WHERE n.name = ? AND f.repo_id = ?" + schema_clause
                 + f" ORDER BY (n.kind = ?) DESC, {kind_rank} ASC, n.node_id ASC LIMIT 1",
-                [name, repo_id] + schema_params + [kind],
+                [name, repo_id, *schema_params, kind],
             ).fetchone()
             if row:
                 return row[0]
@@ -912,7 +913,7 @@ class GraphDB:
             "SELECT n.node_id FROM nodes n "
             "WHERE n.name = ? AND n.file_id IS NOT NULL" + schema_clause
             + f" ORDER BY (n.kind = ?) DESC, {kind_rank} ASC, n.node_id ASC LIMIT 1",
-            [name] + schema_params + [kind],
+            [name, *schema_params, kind],
         ).fetchone()
         return row[0] if row else None
 
@@ -1387,7 +1388,7 @@ class GraphDB:
 
         # params duplicated: once for inner subquery, once not needed for outer
         # (outer filters via the IN subquery)
-        rows = self._execute_read(sql, params + [limit, offset]).fetchall()
+        rows = self._execute_read(sql, [*params, limit, offset]).fetchall()
 
         # Group by (output_node, output_column, chain_index) into chains
         chains: dict[tuple[str, str, int], dict] = {}
@@ -1749,7 +1750,7 @@ class GraphDB:
             f"WHERE e.target_id IN ({placeholders}) "
             "AND n2.name <> ? "
             f"AND {self._non_dataflow_edge_filter('e', 'n2', 'nt')}",
-            target_ids + [model],
+            [*target_ids, model],
         ).fetchall()
         all_downstream = [{"name": r[0], "kind": r[1]} for r in ds_rows]
 
@@ -2165,7 +2166,7 @@ class GraphDB:
             seen_cycles.add(canonical)
 
             # Resolve names
-            full_path_ids = node_list + [start_node]
+            full_path_ids = [*node_list, start_node]
             placeholders = ",".join("?" for _ in full_path_ids)
             name_rows = self._execute_read(
                 f"SELECT node_id, name FROM nodes WHERE node_id IN ({placeholders})",
@@ -2322,7 +2323,7 @@ class GraphDB:
 
         Args:
             min_downstream: Minimum downstream (dependents) count to include
-                a node (default 5, clamped 1–100).
+                a node (default 5, clamped 1-100).
             repo: Optional repo name filter.
 
         Returns:
@@ -2680,7 +2681,7 @@ class GraphDB:
                 f"AND {self._non_dataflow_edge_filter('e', 'n2', 'nt')} "
                 f"LIMIT ? OFFSET ?"
             )
-            for r in self._execute_read(inbound_sql, node_ids + [limit, offset]).fetchall():
+            for r in self._execute_read(inbound_sql, [*node_ids, limit, offset]).fetchall():
                 entry = {
                     "name": r[0],
                     "kind": r[1],
@@ -2710,7 +2711,7 @@ class GraphDB:
                 f"AND {self._non_dataflow_edge_filter('e', 'ns', 'n2')} "
                 f"LIMIT ? OFFSET ?"
             )
-            for r in self._execute_read(outbound_sql, node_ids + [limit, offset]).fetchall():
+            for r in self._execute_read(outbound_sql, [*node_ids, limit, offset]).fetchall():
                 entry = {
                     "name": r[0],
                     "kind": r[1],
@@ -2783,7 +2784,7 @@ class GraphDB:
             f"LIMIT ? OFFSET ?"
         )
 
-        rows = self._execute_read(sql, params + [limit, offset]).fetchall()
+        rows = self._execute_read(sql, [*params, limit, offset]).fetchall()
 
         usage = []
         for r in rows:
@@ -2871,7 +2872,7 @@ class GraphDB:
             f"ORDER BY n.name "
             f"LIMIT ? OFFSET ?"
         )
-        rows = self._execute_read(sql, params + [limit, offset]).fetchall()
+        rows = self._execute_read(sql, [*params, limit, offset]).fetchall()
 
         matches = []
         for r in rows:
@@ -3262,7 +3263,7 @@ class GraphDB:
         LIMIT ?
         """
 
-        params: list = [start_name] + seed_kind_params + [max_depth, limit]
+        params: list = [start_name, *seed_kind_params, max_depth, limit]
         rows = self._execute_read(recursive_sql, params).fetchall()
 
         paths: list[dict] = []

--- a/src/sqlprism/core/indexer.py
+++ b/src/sqlprism/core/indexer.py
@@ -891,7 +891,7 @@ class Indexer:
                 for node in result.nodes
             ]
             node_ids = self.graph.insert_nodes_batch(node_rows)
-            for node, nid in zip(result.nodes, node_ids):
+            for node, nid in zip(result.nodes, node_ids, strict=False):
                 schema = (node.metadata or {}).get("schema") if node.metadata else None
                 node_id_map[(node.name, node.kind, schema)] = nid
             stats["nodes_added"] += len(result.nodes)

--- a/src/sqlprism/core/mcp_tools.py
+++ b/src/sqlprism/core/mcp_tools.py
@@ -693,11 +693,11 @@ async def pr_impact(params: PrImpactInput) -> dict:
 
     # Determine which repo
     if params.repo:
-        path, dialect, dialect_overrides = _resolve_repo_config(params.repo)
+        path, dialect, _dialect_overrides = _resolve_repo_config(params.repo)
         repo_path = Path(path)
     elif len(config["repos"]) == 1:
-        repo_name = list(config["repos"].keys())[0]
-        path, dialect, dialect_overrides = _resolve_repo_config(repo_name)
+        repo_name = next(iter(config["repos"].keys()))
+        path, dialect, _dialect_overrides = _resolve_repo_config(repo_name)
         repo_path = Path(path)
     else:
         return {"error": "Multiple repos configured — specify which repo to analyse."}
@@ -1072,7 +1072,7 @@ async def reindex(params: ReindexInput) -> dict:
                 def _blocking():
                     global _reindex_status
                     results = {}
-                    for name, cfg in repos.items():
+                    for name, _cfg in repos.items():
                         _reindex_status = {**_reindex_status, "current_repo": name}
                         path, dialect, dialect_overrides = _resolve_repo_config(name)
                         results[name] = indexer.reindex_repo(
@@ -1421,7 +1421,7 @@ async def reindex_files(params: ReindexFilesInput) -> dict:
     for path in sql_files:
         resolved = state.indexer._resolve_file_repo(Path(path).resolve(), all_repos)
         if resolved:
-            repo_id, repo_name, repo_path, repo_type = resolved
+            _repo_id, repo_name, _repo_path, repo_type = resolved
             grouped[(repo_name, repo_type)].append(path)
             enqueued += 1
         else:

--- a/src/sqlprism/languages/dbt.py
+++ b/src/sqlprism/languages/dbt.py
@@ -25,6 +25,8 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 from sqlprism.languages.sql import SqlParser
 from sqlprism.languages.sqlmesh import _merge_column_schemas, _validate_command
 from sqlprism.languages.utils import build_env, enrich_nodes, find_venv_dir
@@ -348,15 +350,15 @@ class DbtRenderer:
 
         configured: str | None = None
         try:
-            import yaml
-
             data = yaml.safe_load((project_path / "dbt_project.yml").read_text())
             if isinstance(data, dict):
                 value = data.get("target-path")
                 if isinstance(value, str):
                     configured = value
-        except (ImportError, OSError, Exception):
-            pass
+        except (OSError, yaml.YAMLError) as e:
+            logger.warning(
+                "Could not read target-path from %s/dbt_project.yml: %s", project_path, e,
+            )
 
         if configured:
             p = Path(configured)
@@ -897,12 +899,11 @@ class DbtRenderer:
     ) -> None:
         """Run dbt compile, pointing at the project directory."""
         _validate_command(dbt_command, allowed_keywords={"dbt", "uv", "uvx"})
-        cmd = shlex.split(dbt_command) + [
+        cmd = [
+            *shlex.split(dbt_command),
             "compile",
-            "--project-dir",
-            str(project_path),
-            "--profiles-dir",
-            str(profiles_dir),
+            "--project-dir", str(project_path),
+            "--profiles-dir", str(profiles_dir),
         ]
         if target:
             cmd.extend(["--target", target])
@@ -943,15 +944,15 @@ class DbtRenderer:
 
         content = dbt_project_file.read_text()
 
-        # Try proper YAML parsing first (pyyaml may be available via dbt)
         try:
-            import yaml
-
             data = yaml.safe_load(content)
             if isinstance(data, dict) and "name" in data:
                 return str(data["name"])
-        except (ImportError, Exception):
-            pass
+        except yaml.YAMLError as e:
+            logger.warning(
+                "Could not parse %s as YAML, falling back to line scan: %s",
+                dbt_project_file, e,
+            )
 
         # Fallback: line scanning for top-level name: field
         for line in content.splitlines():
@@ -1014,8 +1015,6 @@ class DbtRenderer:
         two sources sharing a bare name across different schemas must
         resolve to distinct nodes.
         """
-        import yaml
-
         project_path = Path(project_path).resolve()
         models_dir = project_path / "models"
         models: dict[str, list[ColumnDefResult]] = {}

--- a/src/sqlprism/languages/sql.py
+++ b/src/sqlprism/languages/sql.py
@@ -522,7 +522,7 @@ class SqlParser:
             return
 
         seen_scopes = set()
-        for scope in [root_scope] + list(root_scope.traverse()):
+        for scope in [root_scope, *list(root_scope.traverse())]:
             scope_id = id(scope)
             if scope_id in seen_scopes:
                 continue
@@ -1019,7 +1019,7 @@ class SqlParser:
             expression=expr_str if expr_str and expr_str != hop_column else None,
         )
 
-        new_chain = current_chain + [hop]
+        new_chain = [*current_chain, hop]
 
         downstream = node.downstream if hasattr(node, "downstream") else []
         if not downstream:

--- a/src/sqlprism/languages/sqlmesh.py
+++ b/src/sqlprism/languages/sqlmesh.py
@@ -321,12 +321,10 @@ class SqlMeshRenderer:
     ) -> list[str]:
         """Run a lightweight subprocess to discover all model names."""
         _validate_command(sqlmesh_command, allowed_keywords={"python", "sqlmesh", "uv"})
-        cmd = shlex.split(sqlmesh_command) + [
-            "-c",
-            _LIST_MODELS_SCRIPT,
-            str(project_path),
-            dialect,
-            gateway,
+        cmd = [
+            *shlex.split(sqlmesh_command),
+            "-c", _LIST_MODELS_SCRIPT,
+            str(project_path), dialect, gateway,
             json.dumps(variables),
         ]
 
@@ -556,12 +554,10 @@ class SqlMeshRenderer:
             column_schemas maps model_name -> {col_name: data_type}.
         """
         _validate_command(sqlmesh_command, allowed_keywords={"python", "sqlmesh", "uv"})
-        cmd = shlex.split(sqlmesh_command) + [
-            "-c",
-            _RENDER_SCRIPT,
-            str(project_path),
-            dialect,
-            gateway,
+        cmd = [
+            *shlex.split(sqlmesh_command),
+            "-c", _RENDER_SCRIPT,
+            str(project_path), dialect, gateway,
             json.dumps(variables),
             json.dumps(model_filter),
         ]

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -1836,7 +1836,7 @@ def test_tag_storage_upsert():
             ("customer_health", "stg_users"),
         ]
 
-        repo_id, name_to_id = _setup_models_with_edges(db, models, edges)
+        repo_id, _name_to_id = _setup_models_with_edges(db, models, edges)
         engine = ConventionEngine(db, repo_id)
         tags = engine.infer_semantic_tags(threshold=0.5)
         assert len(tags) > 0, "Expected at least one tag assignment"
@@ -2079,7 +2079,7 @@ def test_search_by_tag_ranked():
         confidences = [m["confidence"] for m in result["models"]]
         expected = [0.90, 0.85, 0.70, 0.65]
         assert len(confidences) == len(expected)
-        for actual, exp in zip(confidences, expected):
+        for actual, exp in zip(confidences, expected, strict=False):
             assert abs(actual - exp) < 0.01, f"Expected ~{exp}, got {actual}"
 
         for m in result["models"]:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1318,7 +1318,7 @@ def test_resolve_file_repo_deepest_match(tmp_path):
     file_path = child / "model.sql"
     resolved = indexer._resolve_file_repo(file_path, all_repos)
     assert resolved is not None
-    repo_id, repo_name, repo_path, repo_type = resolved
+    _repo_id, repo_name, _repo_path, repo_type = resolved
     assert repo_name == "child"
     assert repo_type == "dbt"
 
@@ -1624,7 +1624,7 @@ def test_resolve_file_repo_various_layouts(tmp_path):
     # File in child → resolves to child (deepest)
     resolved = indexer._resolve_file_repo(child / "model.sql", all_repos)
     assert resolved is not None
-    repo_id, repo_name, repo_path, repo_type = resolved
+    _repo_id, repo_name, _repo_path, repo_type = resolved
     assert repo_name == "child"
     assert repo_type == "dbt"
 
@@ -3518,7 +3518,7 @@ def test_reindex_dbt_source_identifier_and_schema_keyed_separately(tmp_path):
     ).fetchall()
 
     by_schema: dict[str | None, set[str]] = {}
-    for name, schema, col_name, src in rows:
+    for _name, schema, col_name, src in rows:
         assert src == "schema_yml", rows
         by_schema.setdefault(schema, set()).add(col_name)
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -5,6 +5,7 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 import sqlprism.core.mcp_tools as _mcp_mod
 from sqlprism.core.mcp_tools import (
@@ -100,13 +101,13 @@ def test_configure_sets_repo_type_from_config(tmp_path):
 
 def test_search_input_validation_limit_too_low():
     """SearchInput rejects limit < 1."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         SearchInput(pattern="x", limit=0)
 
 
 def test_search_input_validation_limit_too_high():
     """SearchInput rejects limit > 100."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         SearchInput(pattern="x", limit=200)
 
 
@@ -120,17 +121,17 @@ def test_search_input_validation_limit_boundary():
 
 def test_find_references_input_validation_limit():
     """FindReferencesInput rejects limit out of range."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         FindReferencesInput(name="x", limit=0)
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         FindReferencesInput(name="x", limit=501)
 
 
 def test_find_column_usage_input_validation_limit():
     """FindColumnUsageInput rejects limit out of range."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         FindColumnUsageInput(table="x", limit=0)
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         FindColumnUsageInput(table="x", limit=501)
 
 
@@ -369,9 +370,9 @@ def test_trace_dependencies_not_found(tmp_path):
 
 def test_trace_dependencies_input_validation():
     """TraceDependenciesInput validates max_depth range."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         TraceDependenciesInput(name="x", max_depth=0)
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         TraceDependenciesInput(name="x", max_depth=7)
     # Boundary values are accepted
     inp = TraceDependenciesInput(name="x", max_depth=1)
@@ -909,19 +910,19 @@ def test_pr_impact_delta_mode_includes_note(git_repo):
 
 def test_compare_mode_rejects_invalid():
     """PrImpactInput rejects invalid compare_mode values (1.6a)."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         PrImpactInput(base_commit="HEAD", compare_mode="relative")  # type: ignore[invalid-argument-type]
 
 
 def test_find_references_direction_rejects_invalid():
     """FindReferencesInput rejects invalid direction values (1.6b)."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         FindReferencesInput(name="x", direction="upstream")  # type: ignore[invalid-argument-type]
 
 
 def test_trace_dependencies_direction_rejects_invalid():
     """TraceDependenciesInput rejects invalid direction values (1.6c)."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         TraceDependenciesInput(name="x", direction="inbound")  # type: ignore[invalid-argument-type]
 
 


### PR DESCRIPTION
Closes #134.

## Summary

- **Docs**: align CLAUDE.md on Python 3.11+, fix broken `git clone <repo-url>` examples, drop the hard-coded "24 tools" count from README / CLAUDE.md / guide pages (maintenance liability — it drifted last release).
- **Hygiene**: gitignore `sqlprism.yml` (contains personal paths), `.claude/specs/`, and `.claude/*.lock`. Delete empty `docs/superpowers/` tree. Add `CONTRIBUTING.md`, `CHANGELOG.md` (backfilled from tags v1.0.0 → v1.2.1), and `SECURITY.md`.
- **Silent failures**: narrow `graph.py:74` bare except to `OSError` with a debug log; fix `dbt.py:358` redundant `except (ImportError, OSError, Exception)` tuple — promote `import yaml` to module scope and catch `yaml.YAMLError` + `OSError` with a warning log. Same pattern fixed at `dbt.py:955`.
- **Lint**: expand ruff rules to include `B` (bugbear) and `RUF`. Apply 33 autofixes (list-concat → unpacking, `zip(strict=False)`, prefix unused unpack vars with `_`), split 3 long subprocess command literals, replace en-dash in comments, and narrow 11 `pytest.raises(Exception)` calls in `test_mcp_tools.py` to `ValidationError`.

## Test plan

- [x] `uv run ruff check .` — clean with expanded rules.
- [x] `uv run ty check` — clean.
- [x] `uv run pytest tests/ -v` — 637 passed.
- [ ] Human sanity-check of CHANGELOG wording for v1.0.0 — v1.2.1.
- [ ] Verify SECURITY.md reporting email is the one you want published.

## Out of scope (deferred)

- Test file reorganisation (test_indexer.py is ~3.7k lines).
- Migrating `ty` → `mypy`/`pyright` (`ty` is still 0.0.x).
- cli.py bloat; `core/naming.py` single-function module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)