### PR TITLE
chore: release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.2] — 2026-04-21
+
+### Changed
+- CLI commands now share `_open_graph_for_write` / `_open_graph_for_read`
+  context-manager helpers, replacing the ad-hoc "load config + resolve
+  db_path + open graph" prologue across `reindex`, `reindex-file`,
+  `reindex-sqlmesh`, `reindex-dbt`, `status`, `conventions`, and the five
+  query subcommands (#137).
+- Split `tests/test_indexer.py`, `tests/test_conventions.py`, and
+  `tests/test_mcp_tools.py` into smaller per-feature files; shared MCP
+  reset fixture moved to `tests/conftest.py` (#136).
+- Expand ruff rules to include `B` (bugbear) and `RUF`; narrow
+  `pytest.raises(Exception)` to `ValidationError` in tests (#134).
+
+### Fixed
+- `graph.py` snippet reader now narrows the except to `OSError` and logs
+  at debug instead of silently swallowing; `dbt.py` replaces broad
+  `except (ImportError, OSError, Exception)` with `yaml.YAMLError` +
+  `OSError` and logs failures (#134).
+
+### Docs
+- Align `CLAUDE.md` on Python 3.11+; replace placeholder `<repo-url>`
+  with real clone URL; drop hardcoded tool count from README and guides;
+  add `CONTRIBUTING.md`, `CHANGELOG.md`, and `SECURITY.md` (#134).
+
 ## [1.2.1] — 2026-04-21
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sqlprism"
-version = "1.2.1"
+version = "1.2.2"
 description = "SQL codebase indexer with column-level lineage, impact analysis, and MCP server support"
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/tests/test_indexer_core.py
+++ b/tests/test_indexer_core.py
@@ -16,9 +16,9 @@ from sqlprism.types import (
 
 
 def test_version_string():
-    """Verify package version is 1.2.1."""
+    """Verify package version is 1.2.2."""
     version = importlib.metadata.version("sqlprism")
-    assert version == "1.2.1"
+    assert version == "1.2.2"
 
 
 def test_resolve_dialect_no_overrides():

--- a/uv.lock
+++ b/uv.lock
@@ -1436,7 +1436,7 @@ wheels = [
 
 [[package]]
 name = "sqlprism"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump version 1.2.1 → 1.2.2.
- CHANGELOG entry covering the three chore PRs merged since v1.2.1: CLI graph context-managers (#139), test-file splits (#138), and critical-review docs/hygiene/silent-failure cleanup (#135).

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest tests/test_indexer_core.py::test_version_string -v`
- [x] Tag `v1.2.2` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)